### PR TITLE
Include algorithm header for std::max

### DIFF
--- a/c/enc/jpeg_data_reader.cc
+++ b/c/enc/jpeg_data_reader.cc
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "../common/constants.h"
 #include "../common/jpeg_data.h"


### PR DESCRIPTION
Apparently, clang builds it anyway, but other compilers do not. `std::max` is defined in `<algorithm>` header.