### PR TITLE
Support for other compilers in CMake lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 
-# Set compilers to default to Clang is not set.
-if ("$ENV{CC}" STREQUAL "")
-  set(ENV{CC} clang)
-endif()
-if ("$ENV{CXX}" STREQUAL "")
-  set(ENV{CXX} clang++)
-endif()
-
 project(BRUNSLI C CXX)
 
 # Recommend clang for building.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,71 +10,82 @@ endif()
 
 project(BRUNSLI C CXX)
 
-# Require clang for building.
+# Recommend clang for building.
 if(NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR
    NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} compiler is not supported.\n"
-    "Use clang instead:\n  CC=clang CXX=clang++ cmake ..")
-endif()
-if ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS 6 OR
-    "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 6)
-  message(FATAL_ERROR
-    "Minimum Clang version required is Clang 6, please update.")
+  message(WARNING "Using ${CMAKE_CXX_COMPILER_ID} compiler.\n"
+    "For best results, use clang instead:\n  CC=clang CXX=clang++ cmake ..")
+  if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    if ("${CMAKE_C_COMPILER_VERSION}" VERSION_LESS 6)
+      message(FATAL_ERROR
+        "Minimum Clang version required is Clang 6, please update.")
+    endif()
+  endif()
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    if ("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 6)
+      message(FATAL_ERROR
+        "Minimum Clang version required is Clang 6, please update.")
+    endif()
+  endif()
 endif()
 
 # CMAKE_EXPORT_COMPILE_COMMANDS is used to generate the compilation database
 # used by clang-tidy.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# Global compiler flags for all targets here and in subdirectories.
-add_definitions(
-  # Define "register" as empty since it was deprecated already.
-  -Dregister=
+if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR
+   "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
-  # Avoid changing the binary based on the current time and date.
-  -D__DATE__="redacted"
-  -D__TIMESTAMP__="redacted"
-  -D__TIME__="redacted"
-)
+  # Global compiler flags for all targets here and in subdirectories.
+  add_definitions(
+    # Define "register" as empty since it was deprecated already.
+    -Dregister=
 
-# In CMake before 3.12 it is problematic to pass repeated flags like -Xclang.
-# For this reason we place them in CMAKE_CXX_FLAGS instead.
-# See https://gitlab.kitware.com/cmake/cmake/issues/15826
+    # Avoid changing the binary based on the current time and date.
+    -D__DATE__="redacted"
+    -D__TIMESTAMP__="redacted"
+    -D__TIME__="redacted"
+  )
 
-# Pretty colorful messages within reasonable limits.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-  -Xclang -ferror-limit -Xclang 19 -Xclang -fmessage-length -Xclang 0 \
-  -fdiagnostics-show-option -fcolor-diagnostics")
+  # In CMake before 3.12 it is problematic to pass repeated flags like -Xclang.
+  # For this reason we place them in CMAKE_CXX_FLAGS instead.
+  # See https://gitlab.kitware.com/cmake/cmake/issues/15826
 
-# Machine flags.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-  -mrelax-all \
-  -Xclang -mrelocation-model -Xclang pic \
-  -Xclang -pic-level -Xclang 2 \
-  -Xclang -mdisable-fp-elim \
-  -Xclang -mconstructor-aliases \
-  -mpie-copy-relocations \
-  -Xclang -munwind-tables")
+  # Pretty colorful messages within reasonable limits.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+    -Xclang -ferror-limit -Xclang 19 -Xclang -fmessage-length -Xclang 0 \
+    -fdiagnostics-show-option -fcolor-diagnostics")
 
-# CPU flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-  -mavx2 \
-  -mfma \
-  -Xclang -mprefer-vector-width=128 \
-  -Xclang -target-cpu -Xclang haswell \
-  -Xclang -target-feature -Xclang +avx2")
+  # Machine flags.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+    -mrelax-all \
+    -Xclang -mrelocation-model -Xclang pic \
+    -Xclang -pic-level -Xclang 2 \
+    -Xclang -mdisable-fp-elim \
+    -Xclang -mconstructor-aliases \
+    -mpie-copy-relocations \
+    -Xclang -munwind-tables")
+
+  # CPU flags
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+    -mavx2 \
+    -mfma \
+    -Xclang -mprefer-vector-width=128 \
+    -Xclang -target-cpu -Xclang haswell \
+    -Xclang -target-feature -Xclang +avx2")
+
+  add_compile_options(
+    # Ignore this to allow redefining __DATE__ and others.
+    -Wno-builtin-macro-redefined
+    
+    # Global warning settings.
+    -Wall
+    -Werror
+  )  
+endif()
 
 # Force build with optimizations in release mode.
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
-
-add_compile_options(
-  # Ignore this to allow redefining __DATE__ and others.
-  -Wno-builtin-macro-redefined
-
-  # Global warning settings.
-  -Wall
-  -Werror
-)
 
 include(GNUInstallDirs)
 

--- a/brunsli.cmake
+++ b/brunsli.cmake
@@ -58,101 +58,104 @@ target_link_libraries(brunslienc-static PRIVATE
 )
 
 foreach(lib brunslicommon-static brunslidec-static brunslienc-static)
-  target_compile_options(${lib} PUBLIC
-    # Debug flags
-    -dwarf-column-info
-    -debug-info-kind=line-tables-only
-    -dwarf-version=4
-    -debugger-tuning=gdb
+  if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR
+     "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(${lib} PUBLIC
+      # Debug flags
+      -dwarf-column-info
+      -debug-info-kind=line-tables-only
+      -dwarf-version=4
+      -debugger-tuning=gdb
 
-    # F_FLAGS
-    -fmerge-all-constants
-    -fno-builtin-fwrite
-    -fno-builtin-fread
-    -fno-signed-char
-    -fsized-deallocation
-    -fnew-alignment=8
-    -fno-cxx-exceptions
-    -fno-exceptions
-    -fno-slp-vectorize
-    -fno-vectorize
+      # F_FLAGS
+      -fmerge-all-constants
+      -fno-builtin-fwrite
+      -fno-builtin-fread
+      -fno-signed-char
+      -fsized-deallocation
+      -fnew-alignment=8
+      -fno-cxx-exceptions
+      -fno-exceptions
+      -fno-slp-vectorize
+      -fno-vectorize
 
-    # WARN_FLAGS
-    -Wformat-security
-    -Wno-char-subscripts
-    -Wno-error=deprecated-declarations
-    -Wno-sign-compare
-    -Wno-strict-overflow
-    -Wno-unused-function
-    -Wthread-safety-analysis
-    -Wno-unknown-warning-option
-    -Wno-unused-command-line-argument
-    -Wno-ignored-optimization-argument
-    -Wno-ambiguous-member-template
-    -Wno-pointer-sign
-    -Wno-address-of-packed-member
-    -Wno-enum-compare-switch
-    -Wno-expansion-to-defined
-    -Wno-extern-c-compat
-    -Wno-gnu-alignof-expression
-    -Wno-gnu-designator
-    -Wno-gnu-variable-sized-type-not-at-end
-    -Wno-ignored-attributes
-    -Wno-ignored-qualifiers
-    -Wno-inconsistent-missing-override
-    -Wno-invalid-source-encoding
-    -Wno-mismatched-tags
-    -Wno-potentially-evaluated-expression
-    -Wno-return-std-move
-    -Wno-self-assign-overloaded
-    -Wno-tautological-constant-compare
-    -Wno-tautological-constant-in-range-compare
-    -Wno-tautological-type-limit-compare
-    -Wno-tautological-undefined-compare
-    -Wno-tautological-unsigned-zero-compare
-    -Wno-tautological-unsigned-enum-zero-compare
-    -Wno-undefined-func-template
-    -Wno-unknown-pragmas
-    -Wno-unused-const-variable
-    -Wno-unused-lambda-capture
-    -Wno-unused-local-typedef
-    -Wno-unused-private-field
-    -Wno-private-header
-    -Wfloat-overflow-conversion
-    -Wfloat-zero-conversion
-    -Wfor-loop-analysis
-    -Wgnu-redeclared-enum
-    -Winfinite-recursion
-    -Wliteral-conversion
-    -Wself-assign
-    -Wstring-conversion
-    -Wtautological-overlap-compare
-    -Wunused-comparison
-    -Wvla
-    -Wno-reserved-user-defined-literal
-    -Wno-return-type-c-linkage
-    -Wno-deprecated
-    -Wno-invalid-offsetof
-    -Wno-literal-suffix
-    -Woverloaded-virtual
-    -Wnon-virtual-dtor
-    -Wdeprecated-increment-bool
-    -Wc++11-compat
-    -Wno-c++11-compat-binary-literal
-    -Wc++2a-extensions
-    -Wno-register
-    -Wno-dynamic-exception-spec
-    -Wprivate-header
-    -Wno-builtin-macro-redefined
+      # WARN_FLAGS
+      -Wformat-security
+      -Wno-char-subscripts
+      -Wno-error=deprecated-declarations
+      -Wno-sign-compare
+      -Wno-strict-overflow
+      -Wno-unused-function
+      -Wthread-safety-analysis
+      -Wno-unknown-warning-option
+      -Wno-unused-command-line-argument
+      -Wno-ignored-optimization-argument
+      -Wno-ambiguous-member-template
+      -Wno-pointer-sign
+      -Wno-address-of-packed-member
+      -Wno-enum-compare-switch
+      -Wno-expansion-to-defined
+      -Wno-extern-c-compat
+      -Wno-gnu-alignof-expression
+      -Wno-gnu-designator
+      -Wno-gnu-variable-sized-type-not-at-end
+      -Wno-ignored-attributes
+      -Wno-ignored-qualifiers
+      -Wno-inconsistent-missing-override
+      -Wno-invalid-source-encoding
+      -Wno-mismatched-tags
+      -Wno-potentially-evaluated-expression
+      -Wno-return-std-move
+      -Wno-self-assign-overloaded
+      -Wno-tautological-constant-compare
+      -Wno-tautological-constant-in-range-compare
+      -Wno-tautological-type-limit-compare
+      -Wno-tautological-undefined-compare
+      -Wno-tautological-unsigned-zero-compare
+      -Wno-tautological-unsigned-enum-zero-compare
+      -Wno-undefined-func-template
+      -Wno-unknown-pragmas
+      -Wno-unused-const-variable
+      -Wno-unused-lambda-capture
+      -Wno-unused-local-typedef
+      -Wno-unused-private-field
+      -Wno-private-header
+      -Wfloat-overflow-conversion
+      -Wfloat-zero-conversion
+      -Wfor-loop-analysis
+      -Wgnu-redeclared-enum
+      -Winfinite-recursion
+      -Wliteral-conversion
+      -Wself-assign
+      -Wstring-conversion
+      -Wtautological-overlap-compare
+      -Wunused-comparison
+      -Wvla
+      -Wno-reserved-user-defined-literal
+      -Wno-return-type-c-linkage
+      -Wno-deprecated
+      -Wno-invalid-offsetof
+      -Wno-literal-suffix
+      -Woverloaded-virtual
+      -Wnon-virtual-dtor
+      -Wdeprecated-increment-bool
+      -Wc++11-compat
+      -Wno-c++11-compat-binary-literal
+      -Wc++2a-extensions
+      -Wno-register
+      -Wno-dynamic-exception-spec
+      -Wprivate-header
+      -Wno-builtin-macro-redefined
 
-    # Language flags
-    -disable-free
-    -disable-llvm-verifier
-    -discard-value-names
-    # Note: this works only because this is the only -Xclang passed.
-    -Xclang -relaxed-aliasing
-    -fmath-errno
-  )
+      # Language flags
+      -disable-free
+      -disable-llvm-verifier
+      -discard-value-names
+      # Note: this works only because this is the only -Xclang passed.
+      -Xclang -relaxed-aliasing
+      -fmath-errno
+    )
+  endif()
 
   target_include_directories(${lib}
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Before, only clang could be used. Changed this to a warning that recommends clang.
Tested with MSVC (Visual Studio Community 2017, on Windows), gcc and clang (both on Ubuntu)