### PR TITLE
Fix C++ only header bug.

### DIFF
--- a/c/include/brunsli/types.h
+++ b/c/include/brunsli/types.h
@@ -9,7 +9,7 @@
 #ifndef BRUNSLI_COMMON_TYPES_H_
 #define BRUNSLI_COMMON_TYPES_H_
 
-#include <cstddef> /* for size_t */
+#include <stddef.h> /* for size_t */
 
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
 typedef __int8 int8_t;


### PR DESCRIPTION
The types.h file imports cstddef in order to use the size_t type. However, cstddef is only available under C++, meaning that programs and libraries written in pure C, such as ImageMagick will fail to build if they include the brunsli headers. Moreover, if you are including cstddef in your code you should strictly speaking use std::size_t.