### PR TITLE
Add automated Windows builds with AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ### Introduction
-[![Travis Build Status](https://travis-ci.org/google/brunsli.svg?branch=master)](https://travis-ci.org/google/brunsli)
+[![Travis Build Status](https://travis-ci.org/google/brunsli.svg?branch=master)](https://travis-ci.org/google/brunsli) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/google/brunsli?branch=master&svg=true)](https://ci.appveyor.com/project/google/brunsli)
 
 Brunsli is a lossless JPEG repacking library.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,5 @@ build:
   project: brunsli.sln
 
 artifacts:
-  - path: \**\*.*
+  - path: \Release\**\*.*
     name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ image: Visual Studio 2019
 configuration: Release
 
 install:
+  - git submodule update --init
   - cmake .
 
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,5 @@ build:
   project: brunsli.sln
 
 artifacts:
-  - path: bin\**\*.*
+  - path: \**\*.*
     name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+image: Visual Studio 2019
+configuration: Release
+
+install:
+  - cmake .
+
+build:
+  project: brunsli.sln
+
+artifacts:
+  - path: bin\Release\brunsli.exe
+    name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,5 @@ build:
   project: brunsli.sln
 
 artifacts:
-  - path: bin\Release\brunsli.exe
+  - path: bin\*\*.*
     name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,5 @@ build:
   project: brunsli.sln
 
 artifacts:
-  - path: bin\*\*.*
+  - path: bin\**\*.*
     name: $(APPVEYOR_PROJECT_NAME)


### PR DESCRIPTION
Adds an AppVeyor configruatuion that automatically compiles Brunsli with Visual Studio 2019.

It also uploads the [following artifacts](https://ci.appveyor.com/project/EwoutH/brunsli/build/artifacts) to AppVeyor:

- brunslicommon-static.lib
- brunslidec-c.dll
- brunslidec-static.lib
- brunslienc-c.dll
- brunslienc-static.lib
- cbrunsli.exe
- dbrunsli.exe

I could also add a Deploy aspect to the configuration, that automatically pushes these artifacts to [GitHub Releases](https://github.com/google/brunsli/releases) when a release is tagged.