### PR TITLE
Travis CI: Add GCC 8, GCC 9, Clang and Xcode build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
 dist: bionic
 osx_image: xcode11.2
+git:
+  depth: 3
 
 script:
  - mkdir build; cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ git:
   depth: 3
 
 script:
- - mkdir build; cd build
+ - mkdir build
+ - cd build
  - cmake ..
  - make -j
  - sudo make -j install

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ jobs:
     - name: Arm build
       arch: arm64
     - name: GCC 8 build
-      env: CFLAGS="-Werror" CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
+      env: CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
       install: sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get install -qq gcc-8 g++-8
     - name: GCC 9 build
-      env: CFLAGS="-Werror" CC=/usr/bin/gcc-9 CXX=/usr/bin/g++-9
+      env: CC=/usr/bin/gcc-9 CXX=/usr/bin/g++-9
       install: sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get install -qq gcc-9 g++-9
     - name: Clang build
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ git:
   depth: 3
 
 script:
- - mkdir build
- - cd build
+ - mkdir bin; cd bin
  - cmake ..
  - make -j
  - sudo make -j install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
 language: cpp
 dist: bionic
-
-arch:
- - amd64
- - arm64
+osx_image: xcode11.2
 
 script:
  - cmake ./
  - make -j
  - sudo make -j install
+
+jobs:
+  include:
+    - name: Default build (x64, GCC 7)
+    - name: Arm build
+      arch: arm64
+    - name: GCC 8 build
+      env: CFLAGS="-Werror" CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
+      install: sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get install -qq gcc-8 g++-8
+    - name: GCC 9 build
+      env: CFLAGS="-Werror" CC=/usr/bin/gcc-9 CXX=/usr/bin/g++-9
+      install: sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get install -qq gcc-9 g++-9
+    - name: Clang build
+      compiler: clang
+    - name: macOS build
+      os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ dist: bionic
 osx_image: xcode11.2
 
 script:
- - cmake ./
+ - mkdir build; cd build
+ - cmake ..
  - make -j
  - sudo make -j install
 


### PR DESCRIPTION
 - Adds GCC 8, GCC 9 and Clang builds on Linux
 - Adds macOS build with Xcode 11.2
 - Reduces git clone depth to 3 to speedup download times (by about 2s)