### PR TITLE
compress/decompress the truncated JPEG image

### DIFF
--- a/c/common/ans_params.h
+++ b/c/common/ans_params.h
@@ -12,10 +12,10 @@
 
 namespace brunsli {
 
-#define BRUNSLI_ANS_LOG_TAB_SIZE 10u
-#define BRUNSLI_ANS_TAB_SIZE (1u << BRUNSLI_ANS_LOG_TAB_SIZE)
-#define BRUNSLI_ANS_MAX_SYMBOLS 18
-#define BRUNSLI_ANS_SIGNATURE 0x13u  // Initial state, used as CRC.
+#define ANS_LOG_TAB_SIZE 10u
+#define ANS_TAB_SIZE (1u << ANS_LOG_TAB_SIZE)
+#define ANS_MAX_SYMBOLS 18
+#define ANS_SIGNATURE 0x13u  // Initial state, used as CRC.
 
 }  // namespace brunsli
 

--- a/c/common/constants.h
+++ b/c/common/constants.h
@@ -57,12 +57,19 @@ static const uint8_t kBrunsliHistogramDataTag = 0x6;
 static const uint8_t kBrunsliDCDataTag = 0x7;
 static const uint8_t kBrunsliACDataTag = 0x8;
 static const uint8_t kBrunsliOriginalJpgTag = 0x9;
+static const uint8_t kBrunsliExternalTag = 0xa;
 
 // Header section. All fields are varints.
 static const uint8_t kBrunsliHeaderWidthTag = 0x1;
 static const uint8_t kBrunsliHeaderHeightTag = 0x2;
 static const uint8_t kBrunsliHeaderVersionCompTag = 0x3;
 static const uint8_t kBrunsliHeaderSubsamplingTag = 0x4;
+
+// External section, need for truncated jpeg
+static const uint8_t kBrunsliExternalTruncatedTag = 0x5;
+static const uint8_t kBrunsliExternalScanNumTag = 0x6;
+static const uint8_t kBrunsliExternalMarkTruncateTag = 0x7;
+static const uint8_t kBrunsliExternalTruncatePosTag = 0x8;
 
 static const uint8_t kBrunsliSignature[] = {
   SectionMarker(kBrunsliSignatureTag), 0x04, 'B', 0xd2, 0xd5, 'N'

--- a/c/dec/ans_decode.cc
+++ b/c/dec/ans_decode.cc
@@ -15,7 +15,7 @@ namespace brunsli {
 namespace {
 
 bool ANSBuildMapTable(const int counts[], int alphabet_size,
-                      ANSSymbolInfo map[BRUNSLI_ANS_TAB_SIZE]) {
+                      ANSSymbolInfo map[ANS_TAB_SIZE]) {
   int i;
   int pos = 0;
   for (i = 0; i < alphabet_size; ++i) {
@@ -26,7 +26,7 @@ bool ANSBuildMapTable(const int counts[], int alphabet_size,
       map[pos].offset_ = j;
     }
   }
-  return (pos == BRUNSLI_ANS_TAB_SIZE);
+  return (pos == ANS_TAB_SIZE);
 }
 
 }  // namespace
@@ -34,9 +34,8 @@ bool ANSBuildMapTable(const int counts[], int alphabet_size,
 bool ANSDecodingData::ReadFromBitStream(size_t alphabet_size,
                                         BrunsliBitReader* br) {
   std::vector<int> counts(alphabet_size);
-  return (
-      ReadHistogram(BRUNSLI_ANS_LOG_TAB_SIZE, alphabet_size, &counts[0], br) &&
-      ANSBuildMapTable(&counts[0], alphabet_size, map_));
+  return (ReadHistogram(ANS_LOG_TAB_SIZE, alphabet_size, &counts[0], br) &&
+          ANSBuildMapTable(&counts[0], alphabet_size, map_));
 }
 
 }  // namespace brunsli

--- a/c/dec/ans_decode.h
+++ b/c/dec/ans_decode.h
@@ -28,7 +28,7 @@ struct ANSDecodingData {
 
   bool ReadFromBitStream(size_t alphabet_size, BrunsliBitReader* br);
 
-  ANSSymbolInfo map_[BRUNSLI_ANS_TAB_SIZE];
+  ANSSymbolInfo map_[ANS_TAB_SIZE];
 };
 
 class ANSDecoder {
@@ -41,15 +41,15 @@ class ANSDecoder {
   }
 
   int ReadSymbol(const ANSDecodingData& code, BrunsliInput* in) {
-    const uint32_t res = state_ & (BRUNSLI_ANS_TAB_SIZE - 1);
+    const uint32_t res = state_ & (ANS_TAB_SIZE - 1);
     const ANSSymbolInfo& s = code.map_[res];
-    state_ = s.freq_ * (state_ >> BRUNSLI_ANS_LOG_TAB_SIZE) + s.offset_;
+    state_ = s.freq_ * (state_ >> ANS_LOG_TAB_SIZE) + s.offset_;
     if (state_ < (1u << 16u)) {
       state_ = (state_ << 16u) | in->GetNextWord();
     }
     return s.symbol_;
   }
-  bool CheckCRC() const { return state_ == (BRUNSLI_ANS_SIGNATURE << 16u); }
+  bool CheckCRC() const { return state_ == (ANS_SIGNATURE << 16u); }
 
  private:
   uint32_t state_;

--- a/c/dec/decode.cc
+++ b/c/dec/decode.cc
@@ -4,13 +4,20 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include <brunsli/decode.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <cstring>
 
+#include <brunsli/decode.h>
 #include <brunsli/jpeg_data.h>
 #include <brunsli/status.h>
 #include <brunsli/types.h>
 #include <brunsli/brunsli_decode.h>
 #include <brunsli/jpeg_data_writer.h>
+
+#include "groups.h"
+#include "highwayhash/data_parallel.h"
 
 /* C API for brunsli encoder */
 
@@ -20,6 +27,12 @@ struct OutputStruct {
   size_t (*fun)(void* out_data, const uint8_t* buf, size_t size);
   void* data;
 };
+
+int StringWriter(void* data, const uint8_t* buf, size_t count) {
+  std::string* output = reinterpret_cast<std::string*>(data);
+  output->append(reinterpret_cast<const char*>(buf), count);
+  return count;
+}
 
 int DecodeBrunsli(size_t in_size, const uint8_t* in, void* out_data,
                   DecodeBrunsliSink out_fun) {
@@ -40,6 +53,32 @@ int DecodeBrunsli(size_t in_size, const uint8_t* in, void* out_data,
     return 0;
   }
   return 1;  // ok
+}
+
+size_t brunsli_decompress(const char* input, size_t input_size, std::string& output, size_t thread_nums) {
+  brunsli::JPEGData jpg;
+  const uint8_t* input_data = reinterpret_cast<const uint8_t*>(input);
+
+  // 1. decode
+  highwayhash::ThreadPool thread_pool(thread_nums);
+  brunsli::Executor executor = [&](const brunsli::Runnable& runnable, size_t num_tasks) {
+    thread_pool.Run(0, num_tasks, runnable);
+  };
+  bool ok = brunsli::DecodeGroups(input_data, input_size, &jpg, 32, 128, &executor);
+  if (!ok) {
+    fprintf(stderr, "Failed to parse Brunsli input.\n");
+    return false;
+  }
+
+  //2. write jpeg
+  brunsli::JPEGOutput writer(StringWriter, &output);
+  ok = brunsli::WriteJpeg(jpg, writer);
+  if (!ok) {
+    fprintf(stderr, "Failed to serialize JPEG data.\n");
+    return false;
+  }
+
+  return output.size();
 }
 
 } /* extern "C" */

--- a/c/dec/histogram_decode.cc
+++ b/c/dec/histogram_decode.cc
@@ -77,7 +77,7 @@ bool ReadHistogram(int precision_bits, int length, int* counts,
         {2, 6}, {3, 7}, {3, 4}, {4, 1}, {2, 6}, {3, 8}, {3, 5}, {4, 3},
         {2, 6}, {3, 7}, {3, 4}, {4, 2}, {2, 6}, {3, 8}, {3, 5}, {6, 10},
     };
-    int log_counts[BRUNSLI_ANS_MAX_SYMBOLS];
+    int log_counts[ANS_MAX_SYMBOLS];
     int omit_log = -1;
     int omit_pos = -1;
     BRUNSLI_DCHECK(real_length > 2);

--- a/c/dec/huffman_table.cc
+++ b/c/dec/huffman_table.cc
@@ -12,10 +12,10 @@
 
 namespace brunsli {
 
-#define BRUNSLI_MAX_LENGTH 15
+#define MAX_LENGTH 15
 
 /* For current format this constant equals to kNumInsertAndCopyCodes */
-#define BRUNSLI_MAX_CODE_LENGTHS_SIZE 704
+#define MAX_CODE_LENGTHS_SIZE 704
 
 /* Returns reverse(reverse(key, len) + 1, len), where reverse(key, len) is the
    bit-wise reversal of the len least significant bits of key. */
@@ -43,7 +43,7 @@ static inline void ReplicateValue(HuffmanCode* table, int step, int end,
 static inline int NextTableBitSize(const uint16_t* const count, int len,
                                    int root_bits) {
   int left = 1u << (len - root_bits);
-  while (len < BRUNSLI_MAX_LENGTH) {
+  while (len < MAX_LENGTH) {
     left -= count[len];
     if (left <= 0) break;
     ++len;
@@ -67,19 +67,19 @@ int BuildHuffmanTable(HuffmanCode* root_table, int root_bits,
   int table_size;      /* size of current table */
   int total_size;      /* sum of root table size and 2nd level table sizes */
   /* symbols sorted by code length */
-  int sorted[BRUNSLI_MAX_CODE_LENGTHS_SIZE];
+  int sorted[MAX_CODE_LENGTHS_SIZE];
   /* offsets in sorted table for each length */
-  uint16_t offset[BRUNSLI_MAX_LENGTH + 1];
+  uint16_t offset[MAX_LENGTH + 1];
   int max_length = 1;
 
-  if (code_lengths_size > BRUNSLI_MAX_CODE_LENGTHS_SIZE) {
+  if (code_lengths_size > MAX_CODE_LENGTHS_SIZE) {
     return 0;
   }
 
   /* generate offsets into sorted symbol table by code length */
   {
     uint16_t sum = 0;
-    for (len = 1; len <= BRUNSLI_MAX_LENGTH; len++) {
+    for (len = 1; len <= MAX_LENGTH; len++) {
       offset[len] = sum;
       if (count[len]) {
         sum = static_cast<uint16_t>(sum + count[len]);
@@ -101,7 +101,7 @@ int BuildHuffmanTable(HuffmanCode* root_table, int root_bits,
   total_size = table_size;
 
   /* special case code with only one value */
-  if (offset[BRUNSLI_MAX_LENGTH] == 1) {
+  if (offset[MAX_LENGTH] == 1) {
     code.bits = 0;
     code.value = static_cast<uint16_t>(sorted[0]);
     for (key = 0; key < total_size; ++key) {

--- a/c/dec/state.h
+++ b/c/dec/state.h
@@ -96,6 +96,7 @@ void WarmupMeta(JPEGData* jpg, State* state);
 // Core decoding loop.
 BrunsliStatus ProcessJpeg(State* state, JPEGData* jpg);
 
+
 }  // namespace dec
 }  // namespace internal
 }  // namespace brunsli

--- a/c/enc/ans_encode.cc
+++ b/c/enc/ans_encode.cc
@@ -17,7 +17,7 @@ namespace brunsli {
 namespace {
 
 void ANSBuildInfoTable(const int* counts, int alphabet_size,
-                       ANSEncSymbolInfo info[BRUNSLI_ANS_MAX_SYMBOLS]) {
+                       ANSEncSymbolInfo info[ANS_MAX_SYMBOLS]) {
   int total = 0;
   for (int s = 0; s < alphabet_size; ++s) {
     const uint32_t freq = counts[s];
@@ -43,11 +43,11 @@ void BuildAndStoreANSEncodingData(const int* histogram, ANSTable* table,
                                   Storage* storage) {
   int num_symbols;
   int symbols[kMaxNumSymbolsForSmallCode] = {0};
-  std::vector<int> counts(histogram, histogram + BRUNSLI_ANS_MAX_SYMBOLS);
+  std::vector<int> counts(histogram, histogram + ANS_MAX_SYMBOLS);
   int omit_pos;
-  NormalizeCounts(&counts[0], &omit_pos, BRUNSLI_ANS_MAX_SYMBOLS,
-                  BRUNSLI_ANS_LOG_TAB_SIZE, &num_symbols, symbols);
-  ANSBuildInfoTable(&counts[0], BRUNSLI_ANS_MAX_SYMBOLS, table->info_);
+  NormalizeCounts(&counts[0], &omit_pos, ANS_MAX_SYMBOLS, ANS_LOG_TAB_SIZE,
+                  &num_symbols, symbols);
+  ANSBuildInfoTable(&counts[0], ANS_MAX_SYMBOLS, table->info_);
   EncodeCounts(&counts[0], omit_pos, num_symbols, symbols, storage);
 }
 

--- a/c/enc/ans_encode.h
+++ b/c/enc/ans_encode.h
@@ -16,45 +16,45 @@
 
 namespace brunsli {
 
-// #define BRUNSLI_USE_MULT_BY_RECIPROCAL
+// #define USE_MULT_BY_RECIPROCAL
 
 // precision must be equal to: #bits(state_) + #bits(freq)
-#define BRUNSLI_RECIPROCAL_PRECISION 42
+#define RECIPROCAL_PRECISION 42
 
 // Data structure representing one element of the encoding table built
 // from a distribution.
 struct ANSEncSymbolInfo {
   uint16_t freq_;
   uint16_t start_;
-#ifdef BRUNSLI_USE_MULT_BY_RECIPROCAL
+#ifdef USE_MULT_BY_RECIPROCAL
   uint64_t ifreq_;
 #endif
 };
 
 struct ANSTable {
-  ANSEncSymbolInfo info_[BRUNSLI_ANS_MAX_SYMBOLS];
+  ANSEncSymbolInfo info_[ANS_MAX_SYMBOLS];
 };
 
 class ANSCoder {
  public:
-  ANSCoder() : state_(BRUNSLI_ANS_SIGNATURE << 16) {}
+  ANSCoder() : state_(ANS_SIGNATURE << 16) {}
 
   uint32_t PutSymbol(const ANSEncSymbolInfo t, uint8_t* nbits) {
     uint32_t bits = 0;
     *nbits = 0;
-    if ((state_ >> (32 - BRUNSLI_ANS_LOG_TAB_SIZE)) >= t.freq_) {
+    if ((state_ >> (32 - ANS_LOG_TAB_SIZE)) >= t.freq_) {
       bits = state_ & 0xffff;
       state_ >>= 16;
       *nbits = 16;
     }
-#ifdef BRUNSLI_USE_MULT_BY_RECIPROCAL
+#ifdef USE_MULT_BY_RECIPROCAL
     // We use mult-by-reciprocal trick, but that requires 64b calc.
-    const uint32_t v = (state_ * t.ifreq_) >> BRUNSLI_RECIPROCAL_PRECISION;
+    const uint32_t v = (state_ * t.ifreq_) >> RECIPROCAL_PRECISION;
     const uint32_t offset = state_ - v * t.freq_ + t.start_;
-    state_ = (v << BRUNSLI_ANS_LOG_TAB_SIZE) + offset;
+    state_ = (v << ANS_LOG_TAB_SIZE) + offset;
 #else
-    state_ = ((state_ / t.freq_) << BRUNSLI_ANS_LOG_TAB_SIZE) +
-             (state_ % t.freq_) + t.start_;
+    state_ = ((state_ / t.freq_) << ANS_LOG_TAB_SIZE) + (state_ % t.freq_) +
+             t.start_;
 #endif
     return bits;
   }

--- a/c/enc/encode.cc
+++ b/c/enc/encode.cc
@@ -4,12 +4,18 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-#include <brunsli/encode.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <cstring>
 
+#include <brunsli/encode.h>
 #include <brunsli/jpeg_data.h>
 #include <brunsli/types.h>
 #include <brunsli/brunsli_encode.h>
 #include <brunsli/jpeg_data_reader.h>
+#include "groups.h"
+#include "highwayhash/data_parallel.h"
 
 /* C API for brunsli encoder */
 
@@ -17,6 +23,7 @@ extern "C" {
 
 int EncodeBrunsli(size_t insize, const unsigned char* in, void* outdata,
     size_t (*outfun)(void* outdata, const unsigned char* buf, size_t size)) {
+
   std::vector<uint8_t> output;
   brunsli::JPEGData jpg;
   if (!brunsli::ReadJpeg(in, insize, brunsli::JPEG_READ_ALL, &jpg)) {
@@ -28,11 +35,42 @@ int EncodeBrunsli(size_t insize, const unsigned char* in, void* outdata,
     return 0;
   }
   output.resize(output_size);
+
   if (!outfun(outdata, reinterpret_cast<const unsigned char*>(output.data()),
       output.size())) {
     return 0;
   }
   return 1;  /* ok */
+}
+
+size_t brunsli_compress(const char* input, size_t input_size, std::string& output, size_t thread_nums) {
+  brunsli::JPEGData jpg;
+  const uint8_t* input_data = reinterpret_cast<const uint8_t*>(input);
+
+  //1. read jpeg
+  bool ok  = brunsli::ReadJpeg(input_data, input_size, brunsli::JPEG_READ_ALL, &jpg);
+  if (!ok) {
+    fprintf(stderr, "Failed to parse JPEG input.\n");
+    return false;
+  }
+
+  //2. brunsli encode
+  size_t output_size = brunsli::GetMaximumBrunsliEncodedSize(jpg);
+  output.resize(output_size);
+  uint8_t* output_data = reinterpret_cast<uint8_t*>(&output[0]);
+
+  highwayhash::ThreadPool thread_pool(thread_nums);
+  brunsli::Executor executor = [&](const brunsli::Runnable& runnable, size_t num_tasks) {
+      thread_pool.Run(0, num_tasks, runnable);
+  };
+  ok = brunsli::EncodeGroups(jpg, output_data, &output_size, 32, 128, &executor);
+  if (!ok) {
+    fprintf(stderr, "Failed to transform JPEG to Brunsli\n");
+    return false;
+  }
+  output.resize(output_size);
+  
+  return output_size;
 }
 
 }  /* extern "C" */

--- a/c/enc/histogram_encode.cc
+++ b/c/enc/histogram_encode.cc
@@ -18,18 +18,18 @@
 namespace brunsli {
 
 // Static Huffman code for encoding histogram length.
-static const uint8_t kHistogramLengthBitLengths[BRUNSLI_ANS_MAX_SYMBOLS - 2] = {
+static const uint8_t kHistogramLengthBitLengths[ANS_MAX_SYMBOLS - 2] = {
     8, 8, 6, 6, 6, 5, 4, 3, 3, 3, 3, 3, 3, 4, 5, 7,
 };
-static const uint16_t kHistogramLengthSymbols[BRUNSLI_ANS_MAX_SYMBOLS - 2] = {
+static const uint16_t kHistogramLengthSymbols[ANS_MAX_SYMBOLS - 2] = {
     127, 255, 15, 47, 31, 7, 3, 0, 4, 2, 6, 1, 5, 11, 23, 63,
 };
 
 // Static Huffman code for encoding logcounts.
-static const uint8_t kLogCountBitLengths[BRUNSLI_ANS_LOG_TAB_SIZE + 1] = {
+static const uint8_t kLogCountBitLengths[ANS_LOG_TAB_SIZE + 1] = {
     5, 4, 4, 4, 3, 3, 2, 3, 3, 6, 6,
 };
-static const uint16_t kLogCountSymbols[BRUNSLI_ANS_LOG_TAB_SIZE + 1] = {
+static const uint16_t kLogCountSymbols[ANS_LOG_TAB_SIZE + 1] = {
     15, 3, 11, 7, 2, 6, 0, 1, 5, 31, 63,
 };
 
@@ -112,7 +112,7 @@ void NormalizeCounts(int* counts, int* omit_pos, const int length,
   BRUNSLI_DCHECK(symbol_count <= table_size);
 
   const float norm = 1.f * table_size / total;
-  float targets[BRUNSLI_ANS_MAX_SYMBOLS];
+  float targets[ANS_MAX_SYMBOLS];
   for (int n = 0; n < max_symbol; ++n) {
     targets[n] = norm * counts[n];
   }
@@ -129,7 +129,7 @@ void NormalizeCounts(int* counts, int* omit_pos, const int length,
 
 void EncodeCounts(const int* counts, const int omit_pos, const int num_symbols,
                   const int* symbols, Storage* storage) {
-  int max_bits = 5;  // = 1 + Log2Floor(BRUNSLI_ANS_MAX_SYMBOLS - 1);
+  int max_bits = 5;  // = 1 + Log2Floor(ANS_MAX_SYMBOLS - 1);
   if (num_symbols <= 2) {
     // Small tree marker to encode 1-2 symbols.
     WriteBits(1, 1, storage);
@@ -142,17 +142,17 @@ void EncodeCounts(const int* counts, const int omit_pos, const int num_symbols,
       }
     }
     if (num_symbols == 2) {
-      WriteBits(BRUNSLI_ANS_LOG_TAB_SIZE, counts[symbols[0]], storage);
+      WriteBits(ANS_LOG_TAB_SIZE, counts[symbols[0]], storage);
     }
   } else {
     // Mark non-small tree.
     WriteBits(1, 0, storage);
 
     int length = 0;
-    int logcounts[BRUNSLI_ANS_MAX_SYMBOLS] = {0};
+    int logcounts[ANS_MAX_SYMBOLS] = {0};
     int omit_log = 0;
-    for (int i = 0; i < BRUNSLI_ANS_MAX_SYMBOLS; ++i) {
-      BRUNSLI_DCHECK(counts[i] <= BRUNSLI_ANS_TAB_SIZE);
+    for (int i = 0; i < ANS_MAX_SYMBOLS; ++i) {
+      BRUNSLI_DCHECK(counts[i] <= ANS_TAB_SIZE);
       BRUNSLI_DCHECK(counts[i] >= 0);
       if (i == omit_pos) {
         length = i + 1;
@@ -194,13 +194,13 @@ double PopulationCost(const int* data, int total_count) {
     return 7;
   }
 
-  double entropy_bits = total_count * BRUNSLI_ANS_LOG_TAB_SIZE;
+  double entropy_bits = total_count * ANS_LOG_TAB_SIZE;
   int histogram_bits = 0;
   int count = 0;
   int length = 0;
-  if (total_count > BRUNSLI_ANS_TAB_SIZE) {
+  if (total_count > ANS_TAB_SIZE) {
     uint64_t total = total_count;
-    for (int i = 0; i < BRUNSLI_ANS_MAX_SYMBOLS; ++i) {
+    for (int i = 0; i < ANS_MAX_SYMBOLS; ++i) {
       if (data[i] > 0) {
         ++count;
         length = i;
@@ -210,13 +210,13 @@ double PopulationCost(const int* data, int total_count) {
       return 7;
     }
     ++length;
-    const uint64_t max0 = (total * length) >> BRUNSLI_ANS_LOG_TAB_SIZE;
-    const uint64_t max1 = (max0 * length) >> BRUNSLI_ANS_LOG_TAB_SIZE;
-    const uint32_t min_base = (total + max0 + max1) >> BRUNSLI_ANS_LOG_TAB_SIZE;
+    const uint64_t max0 = (total * length) >> ANS_LOG_TAB_SIZE;
+    const uint64_t max1 = (max0 * length) >> ANS_LOG_TAB_SIZE;
+    const uint32_t min_base = (total + max0 + max1) >> ANS_LOG_TAB_SIZE;
     total += min_base * count;
     const int64_t kFixBits = 32;
     const int64_t kFixOne = 1LL << kFixBits;
-    const int64_t kDescaleBits = kFixBits - BRUNSLI_ANS_LOG_TAB_SIZE;
+    const int64_t kDescaleBits = kFixBits - ANS_LOG_TAB_SIZE;
     const int64_t kDescaleOne = 1LL << kDescaleBits;
     const int64_t kDescaleMask = kDescaleOne - 1;
     const uint32_t mult = kFixOne / total;
@@ -245,20 +245,20 @@ double PopulationCost(const int* data, int total_count) {
       }
     }
   } else {
-    double log2norm = BRUNSLI_ANS_LOG_TAB_SIZE - FastLog2(total_count);
+    double log2norm = ANS_LOG_TAB_SIZE - FastLog2(total_count);
     if (data[0] > 0) {
       double log2count = FastLog2(data[0]) + log2norm;
       entropy_bits -= data[0] * log2count;
       length = 0;
       ++count;
     }
-    for (int i = 1; i < BRUNSLI_ANS_MAX_SYMBOLS; ++i) {
+    for (int i = 1; i < ANS_MAX_SYMBOLS; ++i) {
       if (data[i] > 0) {
         double log2count = FastLog2(data[i]) + log2norm;
         int log2floor = static_cast<int>(log2count);
         entropy_bits -= data[i] * log2count;
-        if (log2floor >= BRUNSLI_ANS_LOG_TAB_SIZE) {
-          log2floor = BRUNSLI_ANS_LOG_TAB_SIZE - 1;
+        if (log2floor >= ANS_LOG_TAB_SIZE) {
+          log2floor = ANS_LOG_TAB_SIZE - 1;
         }
         histogram_bits += GetPopulationCountPrecision(log2floor);
         histogram_bits += kLogCountBitLengths[log2floor + 1];
@@ -276,7 +276,7 @@ double PopulationCost(const int* data, int total_count) {
   }
 
   if (count == 2) {
-    return static_cast<int>(entropy_bits) + 1 + 12 + BRUNSLI_ANS_LOG_TAB_SIZE;
+    return static_cast<int>(entropy_bits) + 1 + 12 + ANS_LOG_TAB_SIZE;
   }
 
   histogram_bits += kHistogramLengthBitLengths[length - 3];

--- a/c/enc/histogram_encode.h
+++ b/c/enc/histogram_encode.h
@@ -29,12 +29,13 @@ static const int kMaxNumSymbolsForSmallCode = 4;
 void NormalizeCounts(int* counts, int* omit_pos, const int length,
                      const int precision_bits, int* num_symbols, int* symbols);
 
-// Stores a histogram in counts[0 .. BRUNSLI_ANS_MAX_SYMBOLS) to the bit-stream
-// where the sum of all population counts is BRUNSLI_ANS_TAB_SIZE and the number
-// of symbols with non-zero counts is num_symbols. symbols[0 ..
-// kMaxNumSymbolsForSmallCode) contains the first few symbols with non-zero
-// population counts. Each count must be rounded to a multiple of 1 <<
-// GetPopulationCountPrecision(count), except possibly counts[omit_pos].
+// Stores a histogram in counts[0 .. ANS_MAX_SYMBOLS) to the bit-stream where
+// the sum of all population counts is ANS_TAB_SIZE and the number of symbols
+// with non-zero counts is num_symbols.
+// symbols[0 .. kMaxNumSymbolsForSmallCode) contains the first few symbols
+// with non-zero population counts.
+// Each count must be rounded to a multiple of
+// 1 << GetPopulationCountPrecision(count), except possibly counts[omit_pos].
 void EncodeCounts(const int* counts, const int omit_pos, const int num_symbols,
                   const int* symbols, Storage* storage);
 

--- a/c/enc/jpeg_data_reader.cc
+++ b/c/enc/jpeg_data_reader.cc
@@ -22,7 +22,7 @@ namespace {
 
 // Macros for commonly used error conditions.
 
-#define BRUNSLI_VERIFY_LEN(n)                                                  \
+#define VERIFY_LEN(n)                                                          \
   if (*pos + (n) > len) {                                                      \
     BRUNSLI_LOG_INFO() << "Unexpected end of input:"                           \
                        << " pos=" << *pos << " need=" << (n) << " len=" << len \
@@ -31,14 +31,14 @@ namespace {
     return false;                                                              \
   }
 
-#define BRUNSLI_VERIFY_INPUT(var, low, high, code)                             \
+#define VERIFY_INPUT(var, low, high, code)                                     \
   if (var < low || var > high) {                                               \
     BRUNSLI_LOG_INFO() << "Invalid " << #var << ": " << var << BRUNSLI_ENDL(); \
     jpg->error = JPEGReadError::INVALID_##code;                                \
     return false;                                                              \
   }
 
-#define BRUNSLI_VERIFY_MARKER_END()                                           \
+#define VERIFY_MARKER_END()                                                   \
   if (start_pos + marker_len != *pos) {                                       \
     BRUNSLI_LOG_INFO() << "Invalid marker length:"                            \
                        << " declared=" << marker_len                          \
@@ -47,7 +47,7 @@ namespace {
     return false;                                                             \
   }
 
-#define BRUNSLI_EXPECT_MARKER()                                               \
+#define EXPECT_MARKER()                                                       \
   if (pos + 2 > len || data[pos] != 0xff) {                                   \
     BRUNSLI_LOG_INFO() << "Marker byte (0xff) expected,"                      \
                        << " found: " << (pos < len ? data[pos] : 0)           \
@@ -57,7 +57,9 @@ namespace {
   }
 
 // Returns ceil(a/b).
-inline int DivCeil(int a, int b) { return (a + b - 1) / b; }
+inline int DivCeil(int a, int b) {
+  return (a + b - 1) / b;
+}
 
 inline int ReadUint8(const uint8_t* data, size_t* pos) {
   return data[(*pos)++];
@@ -71,25 +73,25 @@ inline int ReadUint16(const uint8_t* data, size_t* pos) {
 
 // Reads the Start of Frame (SOF) marker segment and fills in *jpg with the
 // parsed data.
-bool ProcessSOF(const uint8_t* data, const size_t len, JpegReadMode mode,
-                size_t* pos, JPEGData* jpg) {
+bool ProcessSOF(const uint8_t* data, const size_t len,
+                JpegReadMode mode, size_t* pos, JPEGData* jpg) {
   if (jpg->width != 0) {
     BRUNSLI_LOG_INFO() << "Duplicate SOF marker." << BRUNSLI_ENDL();
     jpg->error = JPEGReadError::DUPLICATE_SOF;
     return false;
   }
   const size_t start_pos = *pos;
-  BRUNSLI_VERIFY_LEN(8);
+  VERIFY_LEN(8);
   size_t marker_len = ReadUint16(data, pos);
   int precision = ReadUint8(data, pos);
   int height = ReadUint16(data, pos);
   int width = ReadUint16(data, pos);
   int num_components = ReadUint8(data, pos);
-  BRUNSLI_VERIFY_INPUT(precision, 8, 8, PRECISION);
-  BRUNSLI_VERIFY_INPUT(height, 1, kMaxDimPixels, HEIGHT);
-  BRUNSLI_VERIFY_INPUT(width, 1, kMaxDimPixels, WIDTH);
-  BRUNSLI_VERIFY_INPUT(num_components, 1, kMaxComponents, NUMCOMP);
-  BRUNSLI_VERIFY_LEN(3 * num_components);
+  VERIFY_INPUT(precision, 8, 8, PRECISION);
+  VERIFY_INPUT(height, 1, kMaxDimPixels, HEIGHT);
+  VERIFY_INPUT(width, 1, kMaxDimPixels, WIDTH);
+  VERIFY_INPUT(num_components, 1, kMaxComponents, NUMCOMP);
+  VERIFY_LEN(3 * num_components);
   jpg->height = height;
   jpg->width = width;
   jpg->components.resize(num_components);
@@ -109,11 +111,12 @@ bool ProcessSOF(const uint8_t* data, const size_t len, JpegReadMode mode,
     int factor = ReadUint8(data, pos);
     int h_samp_factor = factor >> 4;
     int v_samp_factor = factor & 0xf;
-    BRUNSLI_VERIFY_INPUT(h_samp_factor, 1, kBrunsliMaxSampling, SAMP_FACTOR);
-    BRUNSLI_VERIFY_INPUT(v_samp_factor, 1, kBrunsliMaxSampling, SAMP_FACTOR);
+    VERIFY_INPUT(h_samp_factor, 1, kBrunsliMaxSampling, SAMP_FACTOR);
+    VERIFY_INPUT(v_samp_factor, 1, kBrunsliMaxSampling, SAMP_FACTOR);
     jpg->components[i].h_samp_factor = h_samp_factor;
     jpg->components[i].v_samp_factor = v_samp_factor;
     jpg->components[i].quant_idx = ReadUint8(data, pos);
+    jpg->components[i].max_block_index.resize(v_samp_factor);
     jpg->max_h_samp_factor = std::max(jpg->max_h_samp_factor, h_samp_factor);
     jpg->max_v_samp_factor = std::max(jpg->max_v_samp_factor, v_samp_factor);
   }
@@ -146,7 +149,7 @@ bool ProcessSOF(const uint8_t* data, const size_t len, JpegReadMode mode,
       c->coeffs.resize(c->num_blocks * kDCTBlockSize);
     }
   }
-  BRUNSLI_VERIFY_MARKER_END();
+  VERIFY_MARKER_END();
   return true;
 }
 
@@ -155,14 +158,14 @@ bool ProcessSOF(const uint8_t* data, const size_t len, JpegReadMode mode,
 bool ProcessSOS(const uint8_t* data, const size_t len, size_t* pos,
                 JPEGData* jpg) {
   const size_t start_pos = *pos;
-  BRUNSLI_VERIFY_LEN(3);
+  VERIFY_LEN(3);
   size_t marker_len = ReadUint16(data, pos);
   int comps_in_scan = ReadUint8(data, pos);
-  BRUNSLI_VERIFY_INPUT(comps_in_scan, 1, jpg->components.size(), COMPS_IN_SCAN);
+  VERIFY_INPUT(comps_in_scan, 1, jpg->components.size(), COMPS_IN_SCAN);
 
   JPEGScanInfo scan_info;
   scan_info.components.resize(comps_in_scan);
-  BRUNSLI_VERIFY_LEN(2 * comps_in_scan);
+  VERIFY_LEN(2 * comps_in_scan);
   std::vector<bool> ids_seen(256, false);
   for (int i = 0; i < comps_in_scan; ++i) {
     int id = ReadUint8(data, pos);
@@ -189,16 +192,16 @@ bool ProcessSOS(const uint8_t* data, const size_t len, size_t* pos,
     int c = ReadUint8(data, pos);
     int dc_tbl_idx = c >> 4;
     int ac_tbl_idx = c & 0xf;
-    BRUNSLI_VERIFY_INPUT(dc_tbl_idx, 0, 3, HUFFMAN_INDEX);
-    BRUNSLI_VERIFY_INPUT(ac_tbl_idx, 0, 3, HUFFMAN_INDEX);
+    VERIFY_INPUT(dc_tbl_idx, 0, 3, HUFFMAN_INDEX);
+    VERIFY_INPUT(ac_tbl_idx, 0, 3, HUFFMAN_INDEX);
     scan_info.components[i].dc_tbl_idx = dc_tbl_idx;
     scan_info.components[i].ac_tbl_idx = ac_tbl_idx;
   }
-  BRUNSLI_VERIFY_LEN(3);
+  VERIFY_LEN(3);
   scan_info.Ss = ReadUint8(data, pos);
   scan_info.Se = ReadUint8(data, pos);
-  BRUNSLI_VERIFY_INPUT(scan_info.Ss, 0, 63, START_OF_SCAN);
-  BRUNSLI_VERIFY_INPUT(scan_info.Se, scan_info.Ss, 63, END_OF_SCAN);
+  VERIFY_INPUT(scan_info.Ss, 0, 63, START_OF_SCAN);
+  VERIFY_INPUT(scan_info.Se, scan_info.Ss, 63, END_OF_SCAN);
   int c = ReadUint8(data, pos);
   scan_info.Ah = c >> 4;
   scan_info.Al = c & 0xf;
@@ -238,19 +241,21 @@ bool ProcessSOS(const uint8_t* data, const size_t len, size_t* pos,
     }
   }
   jpg->scan_info.push_back(scan_info);
-  BRUNSLI_VERIFY_MARKER_END();
+  VERIFY_MARKER_END();
   return true;
 }
 
 // Reads the Define Huffman Table (DHT) marker segment and fills in *jpg with
 // the parsed data. Builds the Huffman decoding table in either dc_huff_lut or
 // ac_huff_lut, depending on the type and solt_id of Huffman code being read.
-bool ProcessDHT(const uint8_t* data, const size_t len, JpegReadMode mode,
+bool ProcessDHT(const uint8_t* data, const size_t len,
+                JpegReadMode mode,
                 std::vector<HuffmanTableEntry>* dc_huff_lut,
-                std::vector<HuffmanTableEntry>* ac_huff_lut, size_t* pos,
+                std::vector<HuffmanTableEntry>* ac_huff_lut,
+                size_t* pos,
                 JPEGData* jpg) {
   const size_t start_pos = *pos;
-  BRUNSLI_VERIFY_LEN(2);
+  VERIFY_LEN(2);
   size_t marker_len = ReadUint16(data, pos);
   if (marker_len == 2) {
     BRUNSLI_LOG_INFO() << "DHT marker: no Huffman table found"
@@ -259,7 +264,7 @@ bool ProcessDHT(const uint8_t* data, const size_t len, JpegReadMode mode,
     return false;
   }
   while (*pos < start_pos + marker_len) {
-    BRUNSLI_VERIFY_LEN(1 + kJpegHuffmanMaxBitLength);
+    VERIFY_LEN(1 + kJpegHuffmanMaxBitLength);
     JPEGHuffmanCode huff;
     huff.slot_id = ReadUint8(data, pos);
     int huffman_index = huff.slot_id;
@@ -267,10 +272,10 @@ bool ProcessDHT(const uint8_t* data, const size_t len, JpegReadMode mode,
     HuffmanTableEntry* huff_lut;
     if (is_ac_table) {
       huffman_index -= 0x10;
-      BRUNSLI_VERIFY_INPUT(huffman_index, 0, 3, HUFFMAN_INDEX);
+      VERIFY_INPUT(huffman_index, 0, 3, HUFFMAN_INDEX);
       huff_lut = &(*ac_huff_lut)[huffman_index * kJpegHuffmanLutSize];
     } else {
-      BRUNSLI_VERIFY_INPUT(huffman_index, 0, 3, HUFFMAN_INDEX);
+      VERIFY_INPUT(huffman_index, 0, 3, HUFFMAN_INDEX);
       huff_lut = &(*dc_huff_lut)[huffman_index * kJpegHuffmanLutSize];
     }
     huff.counts[0] = 0;
@@ -287,17 +292,16 @@ bool ProcessDHT(const uint8_t* data, const size_t len, JpegReadMode mode,
       space -= count * (1 << (kJpegHuffmanMaxBitLength - i));
     }
     if (is_ac_table) {
-      BRUNSLI_VERIFY_INPUT(total_count, 0, kJpegHuffmanAlphabetSize,
-                           HUFFMAN_CODE);
+      VERIFY_INPUT(total_count, 0, kJpegHuffmanAlphabetSize, HUFFMAN_CODE);
     } else {
-      BRUNSLI_VERIFY_INPUT(total_count, 0, kJpegDCAlphabetSize, HUFFMAN_CODE);
+      VERIFY_INPUT(total_count, 0, kJpegDCAlphabetSize, HUFFMAN_CODE);
     }
-    BRUNSLI_VERIFY_LEN(total_count);
+    VERIFY_LEN(total_count);
     std::vector<bool> values_seen(256, false);
     for (int i = 0; i < total_count; ++i) {
       uint8_t value = ReadUint8(data, pos);
       if (!is_ac_table) {
-        BRUNSLI_VERIFY_INPUT(value, 0, kJpegDCAlphabetSize - 1, HUFFMAN_CODE);
+        VERIFY_INPUT(value, 0, kJpegDCAlphabetSize - 1, HUFFMAN_CODE);
       }
       if (values_seen[value]) {
         BRUNSLI_LOG_INFO() << "Duplicate Huffman code value " << value
@@ -330,7 +334,7 @@ bool ProcessDHT(const uint8_t* data, const size_t len, JpegReadMode mode,
     }
     jpg->huffman_code.push_back(huff);
   }
-  BRUNSLI_VERIFY_MARKER_END();
+  VERIFY_MARKER_END();
   return true;
 }
 
@@ -339,7 +343,7 @@ bool ProcessDHT(const uint8_t* data, const size_t len, JpegReadMode mode,
 bool ProcessDQT(const uint8_t* data, const size_t len, size_t* pos,
                 JPEGData* jpg) {
   const size_t start_pos = *pos;
-  BRUNSLI_VERIFY_LEN(2);
+  VERIFY_LEN(2);
   size_t marker_len = ReadUint16(data, pos);
   if (marker_len == 2) {
     BRUNSLI_LOG_INFO() << "DQT marker: no quantization table found"
@@ -348,26 +352,27 @@ bool ProcessDQT(const uint8_t* data, const size_t len, size_t* pos,
     return false;
   }
   while (*pos < start_pos + marker_len && jpg->quant.size() < kMaxQuantTables) {
-    BRUNSLI_VERIFY_LEN(1);
+    VERIFY_LEN(1);
     int quant_table_index = ReadUint8(data, pos);
     int quant_table_precision = quant_table_index >> 4;
-    BRUNSLI_VERIFY_INPUT(quant_table_precision, 0, 1, QUANT_TBL_PRECISION);
+    VERIFY_INPUT(quant_table_precision, 0, 1, QUANT_TBL_PRECISION);
     quant_table_index &= 0xf;
-    BRUNSLI_VERIFY_INPUT(quant_table_index, 0, 3, QUANT_TBL_INDEX);
-    BRUNSLI_VERIFY_LEN((quant_table_precision + 1) * kDCTBlockSize);
+    VERIFY_INPUT(quant_table_index, 0, 3, QUANT_TBL_INDEX);
+    VERIFY_LEN((quant_table_precision + 1) * kDCTBlockSize);
     JPEGQuantTable table;
     table.index = quant_table_index;
     table.precision = quant_table_precision;
     for (int i = 0; i < kDCTBlockSize; ++i) {
-      int quant_val =
-          quant_table_precision ? ReadUint16(data, pos) : ReadUint8(data, pos);
-      BRUNSLI_VERIFY_INPUT(quant_val, 1, 65535, QUANT_VAL);
+      int quant_val = quant_table_precision ?
+          ReadUint16(data, pos) :
+          ReadUint8(data, pos);
+      VERIFY_INPUT(quant_val, 1, 65535, QUANT_VAL);
       table.values[kJPEGNaturalOrder[i]] = quant_val;
     }
     table.is_last = (*pos == start_pos + marker_len);
     jpg->quant.push_back(table);
   }
-  BRUNSLI_VERIFY_MARKER_END();
+  VERIFY_MARKER_END();
   return true;
 }
 
@@ -381,21 +386,21 @@ bool ProcessDRI(const uint8_t* data, const size_t len, size_t* pos,
   }
   *found_dri = true;
   const size_t start_pos = *pos;
-  BRUNSLI_VERIFY_LEN(4);
+  VERIFY_LEN(4);
   size_t marker_len = ReadUint16(data, pos);
   int restart_interval = ReadUint16(data, pos);
   jpg->restart_interval = restart_interval;
-  BRUNSLI_VERIFY_MARKER_END();
+  VERIFY_MARKER_END();
   return true;
 }
 
 // Saves the APP marker segment as a string to *jpg.
 bool ProcessAPP(const uint8_t* data, const size_t len, size_t* pos,
                 JPEGData* jpg) {
-  BRUNSLI_VERIFY_LEN(2);
+  VERIFY_LEN(2);
   size_t marker_len = ReadUint16(data, pos);
-  BRUNSLI_VERIFY_INPUT(marker_len, 2, 65535, MARKER_LEN);
-  BRUNSLI_VERIFY_LEN(marker_len - 2);
+  VERIFY_INPUT(marker_len, 2, 65535, MARKER_LEN);
+  VERIFY_LEN(marker_len - 2);
   // Save the marker type together with the app data.
   std::string app_str(reinterpret_cast<const char*>(&data[*pos - 3]),
                       marker_len + 1);
@@ -407,10 +412,10 @@ bool ProcessAPP(const uint8_t* data, const size_t len, size_t* pos,
 // Saves the COM marker segment as a string to *jpg.
 bool ProcessCOM(const uint8_t* data, const size_t len, size_t* pos,
                 JPEGData* jpg) {
-  BRUNSLI_VERIFY_LEN(2);
+  VERIFY_LEN(2);
   size_t marker_len = ReadUint16(data, pos);
-  BRUNSLI_VERIFY_INPUT(marker_len, 2, 65535, MARKER_LEN);
-  BRUNSLI_VERIFY_LEN(marker_len - 2);
+  VERIFY_INPUT(marker_len, 2, 65535, MARKER_LEN);
+  VERIFY_LEN(marker_len - 2);
   std::string com_str(reinterpret_cast<const char*>(&data[*pos - 2]),
                       marker_len);
   *pos += marker_len - 2;
@@ -492,8 +497,8 @@ struct BitReaderState {
       --pos_;
       // If we give back a 0 byte, we need to check if it was a 0xff/0x00 escape
       // sequence, and if yes, we need to give back one more byte.
-      if (pos_ < next_marker_pos_ && data_[pos_] == 0 &&
-          data_[pos_ - 1] == 0xff) {
+      if (pos_ < next_marker_pos_ &&
+          data_[pos_] == 0 && data_[pos_ - 1] == 0xff) {
         --pos_;
       }
     }
@@ -503,6 +508,29 @@ struct BitReaderState {
       return false;
     }
     *pos = pos_;
+    return true;
+  }
+
+  // get truncated block position in bs
+  bool get_pos(JPEGData* jpg, size_t* pos) {
+    // Give back some bytes that we did not use.
+    int unused_bytes_left = bits_left_ >> 3;
+    uint64_t npos = pos_;
+    while (unused_bytes_left-- > 0) {
+      --npos;
+      // If we give back a 0 byte, we need to check if it was a 0xff/0x00 escape
+      // sequence, and if yes, we need to give back one more byte.
+      if (npos < next_marker_pos_ &&
+          data_[npos] == 0 && data_[npos - 1] == 0xff) {
+        --npos;
+      }
+    }
+    if (npos > next_marker_pos_) {
+      // Data ran out before the scan was complete.
+      //BRUNSLI_LOG_INFO() << "get pos Unexpected end of scan." << BRUNSLI_ENDL();
+      return false;
+    }
+    *pos = npos;
     return true;
   }
 
@@ -534,14 +562,19 @@ int ReadSymbol(const HuffmanTableEntry* table, BitReaderState* br) {
 // Returns the DC diff or AC value for extra bits value x and prefix code s.
 // See Tables F.1 and F.2 of the spec.
 int HuffExtend(int x, int s) {
-  return (x < (1 << (s - 1)) ? x + ((-1) << s) + 1 : x);
+  return (x < (1 << (s - 1)) ? x + ((-1) << s ) + 1 : x);
 }
 
 // Decodes one 8x8 block of DCT coefficients from the bit stream.
 bool DecodeDCTBlock(const HuffmanTableEntry* dc_huff,
-                    const HuffmanTableEntry* ac_huff, int Ss, int Se, int Al,
-                    int* eobrun, bool* reset_state, int* num_zero_runs,
-                    BitReaderState* br, JPEGData* jpg, coeff_t* last_dc_coeff,
+                    const HuffmanTableEntry* ac_huff,
+                    int Ss, int Se, int Al,
+                    int* eobrun,
+                    bool* reset_state,
+                    int* num_zero_runs,
+                    BitReaderState* br,
+                    JPEGData* jpg,
+                    coeff_t* last_dc_coeff,
                     coeff_t* coeffs) {
   int s;
   int r;
@@ -632,9 +665,13 @@ bool DecodeDCTBlock(const HuffmanTableEntry* dc_huff,
   return true;
 }
 
-bool RefineDCTBlock(const HuffmanTableEntry* ac_huff, int Ss, int Se, int Al,
-                    int* eobrun, bool* reset_state, BitReaderState* br,
-                    JPEGData* jpg, coeff_t* coeffs) {
+bool RefineDCTBlock(const HuffmanTableEntry* ac_huff,
+                    int Ss, int Se, int Al,
+                    int* eobrun,
+                    bool* reset_state,
+                    BitReaderState* br,
+                    JPEGData* jpg,
+                    coeff_t* coeffs) {
   bool eobrun_allowed = Ss > 0;
   if (Ss == 0) {
     int s = br->ReadBits(1);
@@ -760,7 +797,7 @@ bool ProcessRestart(const uint8_t* data, const size_t len,
     return false;
   }
   int expected_marker = 0xd0 + *next_restart_marker;
-  BRUNSLI_EXPECT_MARKER();
+  EXPECT_MARKER();
   int marker = data[pos + 1];
   if (marker != expected_marker) {
     BRUNSLI_LOG_INFO() << "Did not find expected restart"
@@ -779,7 +816,13 @@ bool ProcessScan(const uint8_t* data, const size_t len,
                  const std::vector<HuffmanTableEntry>& dc_huff_lut,
                  const std::vector<HuffmanTableEntry>& ac_huff_lut,
                  uint16_t scan_progression[kMaxComponents][kDCTBlockSize],
-                 bool is_progressive, size_t* pos, JPEGData* jpg) {
+                 bool is_progressive,
+                 size_t* pos,
+                 JPEGData* jpg,
+                 bool* is_truncated) {
+  jpg->read_scan_numbers++;
+  BRUNSLI_LOG_DEBUG() << "------ProcessScan begin------ " << BRUNSLI_ENDL();
+  
   if (!ProcessSOS(data, len, pos, jpg)) {
     return false;
   }
@@ -803,6 +846,7 @@ bool ProcessScan(const uint8_t* data, const size_t len,
   int next_restart_marker = 0;
   int eobrun = -1;
   int block_scan_index = 0;
+  size_t last_mcu_row = 0;
   const int Al = is_progressive ? scan_info->Al : 0;
   const int Ah = is_progressive ? scan_info->Ah : 0;
   const int Ss = is_progressive ? scan_info->Ss : 0;
@@ -838,12 +882,30 @@ bool ProcessScan(const uint8_t* data, const size_t len,
     jpg->error = JPEGReadError::NON_REPRESENTABLE_AC_COEFF;
     return false;
   }
+  BRUNSLI_LOG_DEBUG() << "MCU_rows: " << MCU_rows << "  MCUs_per_row: " << MCUs_per_row << BRUNSLI_ENDL();
   for (int mcu_y = 0; mcu_y < MCU_rows; ++mcu_y) {
-    for (int mcu_x = 0; mcu_x < MCUs_per_row; ++mcu_x) {
+    //for truncated jpeg pos
+    if (!br.get_pos(jpg, &jpg->last_mcu_row_pos)) {
+      *is_truncated = true;
+      BRUNSLI_LOG_DEBUG() << "is_truncated1, the current rows " << mcu_y + 1 << BRUNSLI_ENDL();
+      BRUNSLI_LOG_DEBUG() << "is_truncated1, the last rows " << last_mcu_row + 1 << BRUNSLI_ENDL();
+      goto READ_END;
+    }
+    last_mcu_row = mcu_y - 1;
+
+    for (int mcu_x = 0; mcu_x < MCUs_per_row; ++mcu_x) {      
+      //for truncated jpeg
+      if (!br.get_pos(jpg, &jpg->last_mcu_pos)) {
+        *is_truncated = true;
+        BRUNSLI_LOG_DEBUG() << "is_truncated2, the current rows " << mcu_y + 1 << BRUNSLI_ENDL();
+        BRUNSLI_LOG_DEBUG() << "is_truncated2, the last rows " << last_mcu_row + 1 << BRUNSLI_ENDL();
+        goto READ_END;
+      }
       // Handle the restart intervals.
       if (jpg->restart_interval > 0) {
         if (restarts_to_go == 0) {
-          if (ProcessRestart(data, len, &next_restart_marker, &br, jpg)) {
+          if (ProcessRestart(data, len,
+                             &next_restart_marker, &br, jpg)) {
             restarts_to_go = jpg->restart_interval;
             memset(last_dc_coeff, 0, sizeof(last_dc_coeff));
             if (eobrun > 0) {
@@ -854,7 +916,11 @@ bool ProcessScan(const uint8_t* data, const size_t len,
             }
             eobrun = -1;  // fresh start
           } else {
-            return false;
+            //for truncated jpeg
+            *is_truncated = true;
+            BRUNSLI_LOG_DEBUG() << "is_truncated3, the current rows " << mcu_y + 1 << BRUNSLI_ENDL();
+            BRUNSLI_LOG_DEBUG() << "is_truncated3, the last rows " << last_mcu_row + 1 << BRUNSLI_ENDL();
+            goto READ_END;
           }
         }
         --restarts_to_go;
@@ -870,7 +936,7 @@ bool ProcessScan(const uint8_t* data, const size_t len,
         int nblocks_y = is_interleaved ? c->v_samp_factor : 1;
         int nblocks_x = is_interleaved ? c->h_samp_factor : 1;
         for (int iy = 0; iy < nblocks_y; ++iy) {
-          for (int ix = 0; ix < nblocks_x; ++ix) {
+          for (int ix = 0; ix < nblocks_x; ++ix) {            
             int block_y = mcu_y * nblocks_y + iy;
             int block_x = mcu_x * nblocks_x + ix;
             int block_idx = block_y * c->width_in_blocks + block_x;
@@ -878,15 +944,26 @@ bool ProcessScan(const uint8_t* data, const size_t len,
             int num_zero_runs = 0;
             coeff_t* coeffs = &c->coeffs[block_idx * kDCTBlockSize];
             if (Ah == 0) {
-              if (!DecodeDCTBlock(dc_lut, ac_lut, Ss, Se, Al, &eobrun,
-                                  &reset_state, &num_zero_runs, &br, jpg,
-                                  &last_dc_coeff[si->comp_idx], coeffs)) {
-                return false;
+              if (!DecodeDCTBlock(dc_lut, ac_lut,
+                                  Ss, Se, Al,
+                                  &eobrun, &reset_state, &num_zero_runs,
+                                  &br, jpg, &last_dc_coeff[si->comp_idx],
+                                  coeffs)) {
+                //for truncated jpeg
+                *is_truncated = true;
+                BRUNSLI_LOG_DEBUG() << "is_truncated4, the current rows " << mcu_y + 1 << BRUNSLI_ENDL();
+                BRUNSLI_LOG_DEBUG() << "is_truncated4, the last rows " << last_mcu_row + 1 << BRUNSLI_ENDL();
+                goto READ_END;
               }
             } else {
-              if (!RefineDCTBlock(ac_lut, Ss, Se, Al, &eobrun, &reset_state,
+              if (!RefineDCTBlock(ac_lut, Ss, Se, Al,
+                                  &eobrun, &reset_state,
                                   &br, jpg, coeffs)) {
-                return false;
+                //for truncated jpeg
+                *is_truncated = true;
+                BRUNSLI_LOG_DEBUG() << "is_truncated5, the current rows " << mcu_y + 1 << BRUNSLI_ENDL();
+                BRUNSLI_LOG_DEBUG() << "is_truncated5, the last rows " << last_mcu_row + 1 << BRUNSLI_ENDL();
+                goto READ_END;
               }
             }
             if (reset_state) {
@@ -899,26 +976,56 @@ bool ProcessScan(const uint8_t* data, const size_t len,
               scan_info->extra_zero_runs.push_back(info);
             }
             ++block_scan_index;
+            // add the max block index for truncated jpeg
+            c->max_block_index[iy] ++;
           }
         }
       }
     }
   }
-  if (eobrun > 0) {
-    BRUNSLI_LOG_INFO() << "End-of-block run too long." << BRUNSLI_ENDL();
-    jpg->error = JPEGReadError::EOB_RUN_TOO_LONG;
-    return false;
+
+  READ_END:
+
+  for (int i = 0; i < jpg->components.size(); ++i) {
+    for (int j = 0; j < jpg->components[i].v_samp_factor; ++j) {
+        BRUNSLI_LOG_DEBUG() << "jpg->components[i].max_block_index[j]:" << jpg->components[i].max_block_index[j] << BRUNSLI_ENDL();
+    }
+  } 
+
+  if (!(*is_truncated)) {
+    BRUNSLI_LOG_DEBUG() << "finish mcu row " << last_mcu_row + 2 << " scan numbers " << jpg->read_scan_numbers << BRUNSLI_ENDL();
+    if (eobrun > 0) {
+      BRUNSLI_LOG_INFO() << "End-of-block run too long." << BRUNSLI_ENDL();
+      jpg->error = JPEGReadError::EOB_RUN_TOO_LONG;
+      return false;
+    }
+    if (!br.FinishStream(jpg, pos)) {
+      *is_truncated = true;
+      *pos = jpg->last_mcu_row_pos;
+      for (int i = 0; i < jpg->components.size(); ++i) {
+        for (int j = 0; j < jpg->components[i].v_samp_factor; ++j) {
+          jpg->components[i].max_block_index[j] = (last_mcu_row + 1) * jpg->components[i].h_samp_factor * MCUs_per_row;
+        }
+      }
+      return true;
+    }
+    if (*pos > len) {
+      BRUNSLI_LOG_INFO() << "Unexpected end of file during scan. pos=" << *pos
+                        << " len=" << len << BRUNSLI_ENDL();
+      jpg->error = JPEGReadError::UNEXPECTED_EOF;
+      return false;
+    }
+  } else {
+    BRUNSLI_LOG_DEBUG() << "last_mcu_row " << last_mcu_row + 1 << " scan numbers " << jpg->read_scan_numbers << BRUNSLI_ENDL();
+    *pos = jpg->last_mcu_row_pos;
+    for (int i = 0; i < jpg->components.size(); ++i) {
+      for (int j = 0; j < jpg->components[i].v_samp_factor; ++j) {
+        jpg->components[i].max_block_index[j] = (last_mcu_row + 1) * jpg->components[i].h_samp_factor * MCUs_per_row;
+        BRUNSLI_LOG_DEBUG() << "jpg->components[i].max_block_index[j]:" << jpg->components[i].max_block_index[j] << BRUNSLI_ENDL();
+      }
+    }
   }
-  if (!br.FinishStream(jpg, pos)) {
-    jpg->error = JPEGReadError::INVALID_SCAN;
-    return false;
-  }
-  if (*pos > len) {
-    BRUNSLI_LOG_INFO() << "Unexpected end of file during scan. pos=" << *pos
-                       << " len=" << len << BRUNSLI_ENDL();
-    jpg->error = JPEGReadError::UNEXPECTED_EOF;
-    return false;
-  }
+  BRUNSLI_LOG_DEBUG() << "------ProcessScan end------ " << BRUNSLI_ENDL();
   return true;
 }
 
@@ -948,13 +1055,15 @@ bool FixupIndexes(JPEGData* jpg) {
 size_t FindNextMarker(const uint8_t* data, const size_t len, size_t pos) {
   // kIsValidMarker[i] == 1 means (0xc0 + i) is a valid marker.
   static const uint8_t kIsValidMarker[] = {
-      1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-      1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-      1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+    1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
   };
   size_t num_skipped = 0;
-  while (pos + 1 < len && (data[pos] != 0xff || data[pos + 1] < 0xc0 ||
-                           !kIsValidMarker[data[pos + 1] - 0xc0])) {
+  while (pos + 1 < len &&
+         (data[pos] != 0xff || data[pos + 1] < 0xc0 ||
+          !kIsValidMarker[data[pos + 1] - 0xc0])) {
     ++pos;
     ++num_skipped;
   }
@@ -967,7 +1076,7 @@ bool ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
               JPEGData* jpg) {
   size_t pos = 0;
   // Check SOI marker.
-  BRUNSLI_EXPECT_MARKER();
+  EXPECT_MARKER();
   int marker = data[pos + 1];
   pos += 2;
   if (marker != 0xd8) {
@@ -981,10 +1090,11 @@ bool ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
   std::vector<HuffmanTableEntry> ac_huff_lut(lut_size);
   bool found_sof = false;
   bool found_dri = false;
-  uint16_t scan_progression[kMaxComponents][kDCTBlockSize] = {{0}};
+  uint16_t scan_progression[kMaxComponents][kDCTBlockSize] = { { 0 } };
 
   jpg->padding_bits.resize(0);
   bool is_progressive = false;  // default
+  bool is_truncated = false;    // add for truncated jpeg
   do {
     // Read next marker.
     size_t num_skipped = FindNextMarker(data, len, pos);
@@ -995,7 +1105,7 @@ bool ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
           std::string(reinterpret_cast<const char*>(&data[pos]), num_skipped));
       pos += num_skipped;
     }
-    BRUNSLI_EXPECT_MARKER();
+    EXPECT_MARKER();
     marker = data[pos + 1];
     pos += 2;
     bool ok = true;
@@ -1026,7 +1136,7 @@ bool ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
       case 0xda:
         if (mode == JPEG_READ_ALL) {
           ok = ProcessScan(data, len, dc_huff_lut, ac_huff_lut,
-                           scan_progression, is_progressive, &pos, jpg);
+                           scan_progression, is_progressive, &pos, jpg, &is_truncated);
         }
         break;
       case 0xdb:
@@ -1074,19 +1184,34 @@ bool ReadJpeg(const uint8_t* data, const size_t len, JpegReadMode mode,
     if (mode == JPEG_READ_HEADER && found_sof) {
       break;
     }
+    if (is_truncated) {
+      // dummy EOI marker for decode
+      jpg->marker_order.push_back(0xd9);              
+      break;
+    }
   } while (marker != 0xd9);
 
-  if (!found_sof) {
+  if (!is_truncated && !found_sof) {
     BRUNSLI_LOG_INFO() << "Missing SOF marker." << BRUNSLI_ENDL();
     jpg->error = JPEGReadError::SOF_NOT_FOUND;
     return false;
   }
 
+  if (is_truncated) {
+    jpg->is_truncated = true;
+  }
+
   // Supplemental checks.
   if (mode == JPEG_READ_ALL) {
     if (pos < len) {
-      jpg->tail_data.assign(reinterpret_cast<const char*>(&data[pos]),
+      if (is_truncated) {
+        BRUNSLI_LOG_DEBUG() << "pos: " << jpg->last_mcu_row_pos - kDCTBlockSize << BRUNSLI_ENDL();
+        jpg->tail_data.assign(reinterpret_cast<const char*>(&data[jpg->last_mcu_row_pos - kDCTBlockSize]),
+                            len - jpg->last_mcu_row_pos + kDCTBlockSize);
+      } else {
+        jpg->tail_data.assign(reinterpret_cast<const char*>(&data[pos]),
                             len - pos);
+      }
     }
     if (!FixupIndexes(jpg)) {
       return false;

--- a/c/enc/state.h
+++ b/c/enc/state.h
@@ -52,7 +52,7 @@ struct Histogram {
   void Add(int val);
   void Merge(const Histogram& other);
 
-  int data_[BRUNSLI_ANS_MAX_SYMBOLS];
+  int data_[ANS_MAX_SYMBOLS];
   int total_count_;
   double bit_cost_;
 };
@@ -82,7 +82,7 @@ class EntropySource {
   void Resize(int num_bands);
   void AddCode(int code, int histo_ix);
   void Merge(const EntropySource& other);
-  std::unique_ptr<EntropyCodes> Finish(const std::vector<int>& offsets);
+  EntropyCodes Finish(const std::vector<int>& offsets);
 
  private:
   int num_bands_;
@@ -145,7 +145,7 @@ int SelectContextBits(size_t num_symbols);
 bool PredictDCCoeffs(State* state);
 void EncodeDC(State* state);
 void EncodeAC(State* state);
-std::unique_ptr<EntropyCodes> PrepareEntropyCodes(State* state);
+EntropyCodes PrepareEntropyCodes(State* state);
 bool BrunsliSerialize(State* state, const JPEGData& jpg, uint32_t skip_sections,
                       uint8_t* data, size_t* len);
 

--- a/c/include/brunsli/decode.h
+++ b/c/include/brunsli/decode.h
@@ -30,6 +30,8 @@ out_data to out_fun.
 int DecodeBrunsli(size_t in_size, const uint8_t* in, void* out_data,
                   DecodeBrunsliSink out_fun);
 
+size_t brunsli_decompress(const char* input, size_t input_size, std::string& output, size_t thread_nums);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 } /* extern "C" */
 #endif

--- a/c/include/brunsli/encode.h
+++ b/c/include/brunsli/encode.h
@@ -27,6 +27,8 @@ to outfun.
 int EncodeBrunsli(size_t insize, const unsigned char* in, void* outdata,
     size_t (*outfun)(void* outdata, const unsigned char* buf, size_t size));
 
+size_t brunsli_compress(const char* input, size_t input_size, std::string& output, size_t thread_nums);
+
 #if defined(__cplusplus) || defined(c_plusplus)
 }  /* extern "C" */
 #endif

--- a/c/include/brunsli/jpeg_data.h
+++ b/c/include/brunsli/jpeg_data.h
@@ -186,7 +186,7 @@ struct JPEGScanInfo {
   std::vector<ExtraZeroRunInfo> extra_zero_runs;
 };
 
-typedef int16_t coeff_t;
+typedef int32_t coeff_t;
 
 // Represents one component of a jpeg file.
 struct JPEGComponent {
@@ -195,7 +195,8 @@ struct JPEGComponent {
                     v_samp_factor(1),
                     quant_idx(0),
                     width_in_blocks(0),
-                    height_in_blocks(0) {}
+                    height_in_blocks(0),
+                    num_blocks(0) {}
 
   // One-byte id of the component.
   int id;
@@ -210,6 +211,8 @@ struct JPEGComponent {
   int width_in_blocks;
   int height_in_blocks;
   int num_blocks;
+  // the max block index for truncated jpeg
+  std::vector<int> max_block_index;
   // The DCT coefficients of this component, laid out block-by-block, divided
   // through the quantization matrix values.
   std::vector<coeff_t> coeffs;
@@ -228,7 +231,11 @@ struct JPEGData {
                original_jpg(NULL),
                original_jpg_size(0),
                error(JPEGReadError::OK),
-               has_zero_padding_bit(false) {}
+               has_zero_padding_bit(false),
+               is_truncated(false),
+               read_scan_numbers(0),
+               last_mcu_pos(0),
+               last_mcu_row_pos(0) {}
 
   int width;
   int height;
@@ -255,6 +262,12 @@ struct JPEGData {
 
   bool has_zero_padding_bit;
   std::vector<int> padding_bits;
+
+  // Extra information required for reconstructing truncated JPEG file
+  bool is_truncated; 
+  int read_scan_numbers;
+  size_t last_mcu_pos;
+  size_t last_mcu_row_pos;
 };
 
 inline bool JPEGDataIs420(const JPEGData& jpg) {

--- a/c/include/brunsli/jpeg_data_writer.h
+++ b/c/include/brunsli/jpeg_data_writer.h
@@ -25,6 +25,21 @@ struct JPEGOutput {
     return (len == 0) || (cb(data, buf, len) == len);
   }
 
+  size_t size() {
+    std::string* output = reinterpret_cast<std::string*>(data);
+    return (*output).size();
+  }
+
+  bool back(size_t len) {
+    std::string* output = reinterpret_cast<std::string*>(data);
+    int i = 0;
+    while (i < len && !output->empty()) {
+      output->pop_back();
+      i++;
+    }
+    return (i == len);
+  }
+
  private:
   JPEGOutputHook cb;
   void* data;

--- a/c/tools/cbrunsli.cc
+++ b/c/tools/cbrunsli.cc
@@ -13,10 +13,20 @@
 #include <brunsli/brunsli_encode.h>
 #include <brunsli/jpeg_data_reader.h>
 
-#if defined(BRUNSLI_EXPERIMENTAL_GROUPS)
-#include "../experimental/groups.h"
-#include <highwayhash/data_parallel.h>
-#endif
+#include <brunsli/jpeg_data.h>
+#include <brunsli/status.h>
+#include <brunsli/types.h>
+#include <brunsli/brunsli_decode.h>
+#include <brunsli/jpeg_data_writer.h>
+
+#include "groups.h"
+#include "highwayhash/data_parallel.h"
+
+int StringWriter(void* data, const uint8_t* buf, size_t count) {
+  std::string* output = reinterpret_cast<std::string*>(data);
+  output->append(reinterpret_cast<const char*>(buf), count);
+  return count;
+}
 
 bool ReadFileInternal(FILE* file, std::string* content) {
   if (fseek(file, 0, SEEK_END) != 0) {
@@ -115,19 +125,13 @@ bool ProcessFile(const std::string& file_name,
     output.resize(output_size);
     uint8_t* output_data = reinterpret_cast<uint8_t*>(&output[0]);
 
-#if defined(BRUNSLI_EXPERIMENTAL_GROUPS)
-    {
-      highwayhash::ThreadPool thread_pool(4);
-      brunsli::Executor executor = [&](const brunsli::Runnable& runnable,
-                                       size_t num_tasks) {
-        thread_pool.Run(0, num_tasks, runnable);
-      };
-      ok = brunsli::EncodeGroups(jpg, output_data, &output_size, 32, 128,
-                                 &executor);
-    }
-#else
-    ok = brunsli::BrunsliEncodeJpeg(jpg, output_data, &output_size);
-#endif
+    highwayhash::ThreadPool thread_pool(4);
+    brunsli::Executor executor = [&](const brunsli::Runnable& runnable,
+                                      size_t num_tasks) {
+      thread_pool.Run(0, num_tasks, runnable);
+    };
+    ok = brunsli::EncodeGroups(jpg, output_data, &output_size, 32, 128,
+                                &executor);
 
     if (!ok) {
       // TODO: use fallback?
@@ -138,6 +142,7 @@ bool ProcessFile(const std::string& file_name,
   }
 
   ok = WriteFile(outfile_name, output);
+
   return ok;
 }
 

--- a/c/tools/dbrunsli.cc
+++ b/c/tools/dbrunsli.cc
@@ -14,10 +14,8 @@
 #include <brunsli/brunsli_decode.h>
 #include <brunsli/jpeg_data_writer.h>
 
-#if defined(BRUNSLI_EXPERIMENTAL_GROUPS)
-#include "../experimental/groups.h"
-#include <highwayhash/data_parallel.h>
-#endif
+#include "groups.h"
+#include "highwayhash/data_parallel.h"
 
 int StringWriter(void* data, const uint8_t* buf, size_t count) {
   std::string* output = reinterpret_cast<std::string*>(data);
@@ -104,27 +102,18 @@ bool ProcessFile(const std::string& file_name,
   std::string input;
   bool ok = ReadFile(file_name, &input);
   if (!ok) return false;
-
   std::string output;
   {
     brunsli::JPEGData jpg;
     const uint8_t* input_data = reinterpret_cast<const uint8_t*>(input.data());
 
-#if defined(BRUNSLI_EXPERIMENTAL_GROUPS)
-    {
-      highwayhash::ThreadPool thread_pool(4);
-      brunsli::Executor executor = [&](const brunsli::Runnable& runnable,
-                                       size_t num_tasks) {
-        thread_pool.Run(0, num_tasks, runnable);
-      };
-      ok = brunsli::DecodeGroups(input_data, input.size(), &jpg, 32, 128,
-                                 &executor);
-    }
-#else
-    brunsli::BrunsliStatus status =
-        brunsli::BrunsliDecodeJpeg(input_data, input.size(), &jpg);
-    ok = (status == brunsli::BRUNSLI_OK);
-#endif
+    highwayhash::ThreadPool thread_pool(4);
+    brunsli::Executor executor = [&](const brunsli::Runnable& runnable,
+                                      size_t num_tasks) {
+      thread_pool.Run(0, num_tasks, runnable);
+    };
+    ok = brunsli::DecodeGroups(input_data, input.size(), &jpg, 32, 128,
+                                &executor);
 
     input.clear();
     input.shrink_to_fit();
@@ -142,7 +131,6 @@ bool ProcessFile(const std::string& file_name,
   }
 
   ok = WriteFile(outfile_name, output);
-
   return ok;
 }
 


### PR DESCRIPTION
pull request: add the function: compress/decompress the truncated JPEG image

what is truncated JPEG image?
A：if there is a large jpeg image, it need to stored in two place, so it's truncated into two parts. First part has jpeg header, the second does not.  The first part is called truncated JPEG image.

Main steps：
1.  find truncated point in read jpeg step
2. add ExternalSection Tag to save the field metadata of the truncated point in brunsli encode step
3. playback the truncated point when decompress brn
4. fill the tail data into jpeg data in write jpeg step
