### PR TITLE
CI: Add weekly run 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,6 @@ jobs:
       with:
         submodules: recursive
 
-    - name: install
-      if: ${{ matrix.env == 'CC=/usr/bin/gcc-10 CXX=/usr/bin/g++-10' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc-10 g++-10
-
     - name: configure
       run: ${{ matrix.env }} cmake -DCMAKE_BUILD_TYPE=Release ${{ matrix.cmake_params }} -B out
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: 0 6 * * 1 # Each Monday at 06:00 UTC
 
 defaults:
   run:


### PR DESCRIPTION
Add weekly run to test updated environments

Also removes the GCC 10 install step, since it's included by default
