### PR TITLE
CI: Remove GCC 7 and 8 jobs, add Clang 10 and 11 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,15 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
         - os: ubuntu
           env: CC=/usr/bin/clang-9 CXX=/usr/bin/clang++-9
         - os: ubuntu
-          env: CC=/usr/bin/gcc-7 CXX=/usr/bin/g++-7
+          env: CC=/usr/bin/clang-10 CXX=/usr/bin/clang++-10
         - os: ubuntu
-          env: CC=/usr/bin/gcc-8 CXX=/usr/bin/g++-8
+          env: CC=/usr/bin/clang-11 CXX=/usr/bin/clang++-11
         - os: ubuntu
           env: CC=/usr/bin/gcc-9 CXX=/usr/bin/g++-9
         - os: ubuntu


### PR DESCRIPTION
I saw the latest scheduled CI run [failed](https://github.com/google/brunsli/actions/runs/718355777), this PR fixes that.
 - Removes the GCC 7 and GCC 8 build jobs on Ubuntu. They have been removed from the images (see https://github.com/actions/virtual-environments/issues/2950).
- Adds Clang 10 and Clang 11 build jobs
- Disable fail-fast in the build matrix, no builds will be cancelled on failure