### PR TITLE
Add exports for MSVC build

### DIFF
--- a/c/include/brunsli/decode.h
+++ b/c/include/brunsli/decode.h
@@ -17,7 +17,7 @@ https://opensource.org/licenses/MIT.
 extern "C" {
 #endif
 
-#if defined(WIN32) && defined(brunslidec_c_EXPORTS)
+#if defined(_MSC_VER) && defined(brunslidec_c_EXPORTS)
 __declspec(dllexport)
 #endif
 typedef size_t (*DecodeBrunsliSink)(void* out_data, const uint8_t* buf,

--- a/c/include/brunsli/decode.h
+++ b/c/include/brunsli/decode.h
@@ -17,6 +17,9 @@ https://opensource.org/licenses/MIT.
 extern "C" {
 #endif
 
+#if defined(WIN32) && defined(brunslidec_c_EXPORTS)
+__declspec(dllexport)
+#endif
 typedef size_t (*DecodeBrunsliSink)(void* out_data, const uint8_t* buf,
                                     size_t size);
 

--- a/c/include/brunsli/encode.h
+++ b/c/include/brunsli/encode.h
@@ -24,7 +24,7 @@ Outputs to outfun, outfun must return amount of consumed bytes, any return value
 not equal to the input size is considered an error. It will pass on the outdata
 to outfun.
 */
-#if defined(WIN32) && defined(brunslienc_c_EXPORTS)
+#if defined(_MSC_VER) && defined(brunslienc_c_EXPORTS)
 __declspec(dllexport)
 #endif
 int EncodeBrunsli(size_t insize, const unsigned char* in, void* outdata,

--- a/c/include/brunsli/encode.h
+++ b/c/include/brunsli/encode.h
@@ -24,6 +24,9 @@ Outputs to outfun, outfun must return amount of consumed bytes, any return value
 not equal to the input size is considered an error. It will pass on the outdata
 to outfun.
 */
+#if defined(WIN32) && defined(brunslienc_c_EXPORTS)
+__declspec(dllexport)
+#endif
 int EncodeBrunsli(size_t insize, const unsigned char* in, void* outdata,
     size_t (*outfun)(void* outdata, const unsigned char* buf, size_t size));
 


### PR DESCRIPTION
On Windows, MSVC needs to have explicit exports for public symbols.