### PR TITLE
Fix unintentionally persistent `std::hex` on output streams

### DIFF
--- a/c/dec/brunsli_decode.cc
+++ b/c/dec/brunsli_decode.cc
@@ -1053,7 +1053,8 @@ static BrunsliStatus ReadTag(State* state, SectionState* section) {
   const uint32_t tag_bit = 1u << tag;
   if (section->tags_met & tag_bit) {
     BRUNSLI_LOG_ERROR() << "Duplicate marker " << std::hex
-                        << static_cast<int>(marker) << BRUNSLI_ENDL();
+                        << static_cast<int>(marker) << std::dec
+                        << BRUNSLI_ENDL();
     return BRUNSLI_INVALID_BRN;
   }
   section->tags_met |= tag_bit;

--- a/c/dec/jpeg_data_writer.cc
+++ b/c/dec/jpeg_data_writer.cc
@@ -1062,7 +1062,7 @@ SerializationStatus SerializeJpeg(State* state, const JPEGData& jpg,
         SerializationStatus status = SerializeSection(marker, *state, &ss, jpg);
         if (status == SerializationStatus::ERROR) {
           BRUNSLI_LOG_DEBUG() << "Failed to encode marker " << std::hex
-                              << marker << BRUNSLI_ENDL();
+                              << marker << std::dec << BRUNSLI_ENDL();
           ss.stage = SerializationState::ERROR;
           break;
         }


### PR DESCRIPTION
`std::hex` is a sticky I/O manipulator. Once set, it affects all subsequent integer output on the stream until explicitly reset with `std::dec`.

Of the 4 usages of `std::hex` in the codebase, 2 were missing a corresponding `std::dec`. This PR adds the missing resets so all usages consistently restore the stream to decimal formatting.

cc: @nunoplopes