### PR TITLE
reject header varint field sent as section

### DIFF
--- a/c/dec/brunsli_decode.cc
+++ b/c/dec/brunsli_decode.cc
@@ -1142,7 +1142,7 @@ Stage DecodeHeader(State* state, JPEGData* jpg) {
         const uint32_t tag_bit = 1u << hs.section.tag;
         if (hs.section.is_section) {
           if (kKnownHeaderVarintTags & tag_bit) {
-            Fail(state, BRUNSLI_INVALID_BRN);
+            return Fail(state, BRUNSLI_INVALID_BRN);
           }
           hs.stage = HeaderState::ITEM_ENTER_SECTION;
           break;

--- a/c/tests/c_api_test.cc
+++ b/c/tests/c_api_test.cc
@@ -7,7 +7,15 @@
 #include <brunsli/decode.h>
 #include <brunsli/encode.h>
 
+#include <vector>
+
+#include <brunsli/brunsli_decode.h>
+#include <brunsli/jpeg_data.h>
+#include <brunsli/status.h>
 #include "gtest/gtest.h"
+
+using ::brunsli::BrunsliDecodeJpeg;
+using ::brunsli::JPEGData;
 
 namespace {
   size_t OutputToString(void* data, const uint8_t* buf, size_t count) {
@@ -48,4 +56,20 @@ TEST(CApiTest, Roundtrip) {
 
   // Roundtrip should be equal to initial string
   ASSERT_EQ(jpeg, jpeg2);
+}
+
+// A header field (width / height / version / subsampling) is a varint. When one
+// is encoded as a length-delimited section instead, the decoder must reject the
+// stream; otherwise the corresponding value is left unset and read later.
+TEST(CApiTest, HeaderVarintTagAsSectionIsRejected) {
+  const std::vector<uint8_t> brn = {
+    0x0A, 0x04, 'B', 0xD2, 0xD5, 'N',  // signature
+    0x12,                              // header tag, length-delimited
+    0x07,                              // header content length
+    0x22,                              // subsampling tag (varint field) as section
+    0x05                               // claimed sub-section length
+  };
+  JPEGData jpg;
+  ASSERT_EQ(brunsli::BRUNSLI_INVALID_BRN,
+            BrunsliDecodeJpeg(brn.data(), brn.size(), &jpg));
 }

--- a/c/tests/c_api_test.cc
+++ b/c/tests/c_api_test.cc
@@ -4,14 +4,14 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+#include <brunsli/brunsli_decode.h>
 #include <brunsli/decode.h>
 #include <brunsli/encode.h>
+#include <brunsli/jpeg_data.h>
+#include <brunsli/status.h>
 
 #include <vector>
 
-#include <brunsli/brunsli_decode.h>
-#include <brunsli/jpeg_data.h>
-#include <brunsli/status.h>
 #include "gtest/gtest.h"
 
 using ::brunsli::BrunsliDecodeJpeg;


### PR DESCRIPTION
DecodeHeader rejects a width/height/version/subsampling field that arrives as a length-delimited section by calling Fail without returning, so a crafted header slips past the check and the field value is left unset in varint_values and read later on. Adding the missing return rejects the stream with BRUNSLI_INVALID_BRN, in line with every other check in the function. I also added a small decode test that feeds such a header and asserts it is rejected.