### PR TITLE
count all component blocks in GetMaximumBrunsliEncodedSize

### DIFF
--- a/c/enc/brunsli_encode.cc
+++ b/c/enc/brunsli_encode.cc
@@ -76,12 +76,13 @@ size_t GetMaximumBrunsliEncodedSize(const JPEGData& jpg) {
     hdr_size += data.size();
   }
   hdr_size += jpg.tail_data.size();
-  size_t x_blocks = (jpg.height + 7) >> 3;
-  size_t y_blocks = (jpg.width + 7) >> 3;
+  size_t num_blocks = 0;
+  for (const auto& component : jpg.components) {
+    num_blocks += component.num_blocks;
+  }
   // Currently established upper bound is 82 bytes per block.
   constexpr size_t kBytesPerBlock = 82 + 2;
-  size_t entropy_size =
-      x_blocks * y_blocks * jpg.components.size() * kBytesPerBlock;
+  size_t entropy_size = num_blocks * kBytesPerBlock;
   return entropy_size + hdr_size;
 }
 


### PR DESCRIPTION
The entropy-size term counts ceil(width/8)*ceil(height/8) blocks per component, but a component real block count is width_in_blocks*height_in_blocks, which is far larger when a sampling factor is high relative to a small image dimension. A single 15x15-sampled component at 65535x8 has 123075 blocks, not the 8192 the old formula assumes, so BrunsliEncodeJpeg overruns the caller-provided buffer while writing the AC section (heap write past the end, caught by ASan at brunsli_encode.cc:715).

I summed each component num_blocks for the block count instead. Reviewers may want to confirm num_blocks is always populated on the encode path; it is set in ProcessSOF right after the SOF dimensions/sampling are read. Existing tests stay green and a crafted JPEG that previously overflowed now encodes into a correctly sized buffer.