### PR TITLE
use int temporaries in DCT block writers to avoid undefined shift

### DIFF
--- a/brunsli.cmake
+++ b/brunsli.cmake
@@ -183,6 +183,7 @@ if (${BUILD_TESTING})
     build_huffman_table
     c_api
     context
+    dct_block
     distributions
     fallback
     headerless

--- a/c/dec/jpeg_data_writer.cc
+++ b/c/dec/jpeg_data_writer.cc
@@ -508,8 +508,8 @@ bool EncodeDCTBlockSequential(const coeff_t* coeffs,
                               const HuffmanCodeTable& ac_huff,
                               int num_zero_runs, coeff_t* last_dc_coeff,
                               BitWriter* bw) {
-  coeff_t temp2;
-  coeff_t temp;
+  int temp2;
+  int temp;
   temp2 = coeffs[0];
   temp = temp2 - *last_dc_coeff;
   *last_dc_coeff = temp2;
@@ -562,8 +562,8 @@ bool EncodeDCTBlockProgressive(const coeff_t* coeffs,
                                DCTCodingState* coding_state,
                                coeff_t* last_dc_coeff, BitWriter* bw) {
   bool eob_run_allowed = Ss > 0;
-  coeff_t temp2;
-  coeff_t temp;
+  int temp2;
+  int temp;
   if (Ss == 0) {
     temp2 = coeffs[0] >> Al;
     temp = temp2 - *last_dc_coeff;

--- a/c/tests/dct_block_test.cc
+++ b/c/tests/dct_block_test.cc
@@ -1,0 +1,50 @@
+// Copyright (c) Google LLC 2019
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include <brunsli/jpeg_data.h>
+#include <brunsli/jpeg_data_reader.h>
+#include <brunsli/jpeg_data_writer.h>
+#include "./test_utils.h"
+
+namespace brunsli {
+
+// An 8x8 pixel baseline JPEG.
+static const char kJpeg[] =
+    "\377\330\377\340\0\20JFIF\0\1\1\1\0`\0`\0\0\377\333\0C\0\b\6\6\a"
+    "\6\5\b\a\a\a\t\t\b\n\f\24\r\f\v\v\f\31\22\23\17\24\35\32\37\36\35"
+    "\32\34\34 $.' \",#\34\34(7),01444\37'9=82<.342\377\333\0C\1\t\t\t"
+    "\f\v\f\30\r\r\0302!\34!22222222222222222222222222222222222222222"
+    "222222222\377\300\0\21\b\0\b\0\b\3\1\"\0\2\21\1\3\21\1\377\304\0"
+    "\25\0\1\1\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\6\377\304\0\32\20\1\1\1\1"
+    "\0\3\0\0\0\0\0\0\0\0\0\0\1\2\0\3\0211A\377\304\0\25\1\1\1\0\0\0\0"
+    "\0\0\0\0\0\0\0\0\0\0\6\a\377\304\0\25\21\1\1\0\0\0\0\0\0\0\0\0\0"
+    "\0\0\0\0\1\0\377\332\0\f\3\1\0\2\21\3\21\0?\0\216\273\276\267W\322"
+    "\232\272U\245\362\253\355_\256fc5\270\0\277\377\331";
+
+// A brunsli stream can decode a DC coefficient that no valid JPEG would carry.
+// The first block's DC difference equals coeffs[0] (last_dc_coeff starts at 0),
+// so a coefficient of INT16_MIN produces a difference whose magnitude is not
+// representable. WriteJpeg must reject it rather than compute a 32-bit Huffman
+// magnitude category and perform an out-of-range bit shift.
+TEST(DctBlockTest, NonRepresentableDcCoeff) {
+  std::string jpeg(kJpeg, sizeof(kJpeg) - 1);
+  JPEGData jpg;
+  ASSERT_TRUE(ReadJpeg(reinterpret_cast<const uint8_t*>(jpeg.data()),
+                       jpeg.size(), JPEG_READ_ALL, &jpg));
+  ASSERT_FALSE(jpg.components.empty());
+  ASSERT_FALSE(jpg.components[0].coeffs.empty());
+
+  jpg.components[0].coeffs[0] = static_cast<coeff_t>(-32768);
+
+  std::string out;
+  JPEGOutput sink(StringOutputFunction, &out);
+  EXPECT_FALSE(WriteJpeg(jpg, sink));
+}
+
+}  // namespace brunsli


### PR DESCRIPTION
EncodeDCTBlockSequential and EncodeDCTBlockProgressive hold the DC difference in a coeff_t (int16). A crafted brunsli stream can decode a DC coefficient of -32768, so the first block's difference is INT16_MIN; negating that overflows and Log2FloorNonZero then reports a magnitude category of 32, so WriteBits evaluates 1u << 32 and shifts by a negative count (UBSan flags jpeg_data_writer.cc:524 while reconstructing such a stream). Widening the two temporaries to int, the way the original libjpeg encoder declares them, keeps the negation and the bit length in range. A valid JPEG's DC difference always fits in this path, so reconstruction of well-formed input is byte-for-byte unchanged; reviewers can confirm that on the roundtrip test. The new dct_block_test feeds a non-representable coefficient and checks that WriteJpeg reports failure instead of performing the out-of-range shift.